### PR TITLE
$where for non numeric data

### DIFF
--- a/modules/incanter-core/project.clj
+++ b/modules/incanter-core/project.clj
@@ -5,4 +5,4 @@
                  [incanter/parallelcolt "0.9.4"]]
   :dev-dependencies [[lein-javac "1.2.1-SNAPSHOT"]
                      [lein-clojars "0.5.0-SNAPSHOT"]]
-  :java-source-path [["src"]])
+  :java-source-path "src")

--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -1204,9 +1204,18 @@
   ([query-map]
    (let [in-fn (fn [value val-set] (some val-set [value]))
          nin-fn (complement in-fn)
-         ops {:gt > :lt < :eq = :ne not= :gte >= :lte <=
+         ops {:gt #(> (compare %1 %2) 0)
+              :lt #(< (compare %1 %2) 0)
+              :eq =
+              :ne not=
+              :gte #(>= (compare %1 %2) 0)
+              :lte #(<= (compare %1 %2) 0)
               :in in-fn :nin nin-fn :fn (fn [v f] (f v))
-              :$gt > :$lt < :$eq = :$ne not= :$gte >= :$lte <= 
+              :$gt #(> (compare %1 %2) 0)
+              :$lt #(< (compare %1 %2) 0)
+              :$eq = :$ne not=
+              :$gte #(>= (compare %1 %2) 0)
+              :$lte #(<= (compare %1 %2) 0)
               :$in in-fn :$nin nin-fn  
               :$fn (fn [v f] (f v))}
          _and (fn [a b] (and a b))] 


### PR DESCRIPTION
$where only worked on numeric data since query-to-pred used the >, <, >=, <= functions.

I changed it to use the compare function. It will now work with numeric data using the clojure number tree _and_ anything that is Comparable.
