### PR TITLE
Support for line+points style plots

### DIFF
--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -565,6 +565,7 @@
 
   Options:
     :series-label (default x expression)
+    :points (default false)
 
   Examples:
 
@@ -995,6 +996,7 @@
     :legend (default false) prints legend
     :series-label (default x expression)
     :group-by (default nil) -- a vector of values used to group the x and y values into series.
+    :points (default false) includes point-markers
 
   See also:
     view, save, add-points, add-lines


### PR DESCRIPTION
For a lot of purposes, I find it useful to include point-markers on line graphs (equivalent to "with linespoints" in gnuplot), but I couldn't see a way to do this using current versions of Incanter.

This patch adds support for a :points option to the add-lines and xy-plot functions.
