### PR TITLE
Weibull distribution functions

### DIFF
--- a/modules/incanter-core/src/incanter/Weibull.java
+++ b/modules/incanter-core/src/incanter/Weibull.java
@@ -1,4 +1,4 @@
-package incanter.random;
+package incanter;
 
 import cern.jet.random.tdouble.*;
 import cern.jet.random.tdouble.engine.*;

--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -36,10 +36,7 @@
            (cern.jet.random.tdouble.engine DoubleMersenneTwister)
            (cern.jet.stat.tdouble DoubleDescriptive
                                   Probability)
-           (incanter.random Weibull))
-  (:use [incanter.probability :only [gt lt binary]])
-  (:use [incanter.transformations :only [map-map same-length? sort-map]])
-  (:use [incanter.internal :only [tree-comp-each]])
+           (incanter Weibull))
   (:use [clojure.contrib.map-utils :only [deep-merge-with]])
   (:use [clojure.set :only [difference intersection union]])
   (:use [incanter.core :only (abs plus minus div mult mmult to-list bind-columns


### PR DESCRIPTION
I've added a set of functions in incanter.stats for the Weibull distribution. This is a commonly-used distribution when dealing with problems like MTBF of hardware components.

This includes a new Java file because Jet doesn't seem to support Weibull. 
