### PR TITLE
- significantly increase parse-string by using a regular expression

### DIFF
--- a/modules/incanter-io/src/incanter/io.clj
+++ b/modules/incanter-io/src/incanter/io.clj
@@ -29,10 +29,11 @@ incanter.io
   (:use [incanter.core :only (dataset save get-input-reader)]))
 
 (defn- parse-string [value]
-  (try (Integer/parseInt value)
-    (catch NumberFormatException _
-      (try (Double/parseDouble value)
-        (catch NumberFormatException _ value)))))
+  (if (re-matches #"\d+" value)
+    (try (Integer/parseInt value)
+         (catch NumberFormatException _ value))
+    (try (Double/parseDouble value)
+         (catch NumberFormatException _ value))))
 
 
 (defn read-dataset


### PR DESCRIPTION
- significantly increase parse-string by using a regular expression to choose a parse\* fn

I have a csv file with mainly floating point data (6000 lines & 6 columns) and it takes about one second using the old version vs. ~100 ms using the one provided with this commit.
This is on clojure 1.3 beta1 though it should also work on clojure 1.2.
