### PR TITLE
Fix swank-clojure dependency.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
                  [incanter/incanter-pdf "1.2.3"]
                  [incanter/incanter-latex "1.2.3"]
                  [incanter/incanter-excel "1.2.3"]
-                 [swank-clojure "1.3.0-SNAPSHOT"]
                  [swingrepl "1.0.0-SNAPSHOT"]
                  [jline "0.9.94"]]
-  :dev-dependencies [[lein-clojars "0.6.0"]]
+  :dev-dependencies [[lein-clojars "0.6.0"]
+                     [swank-clojure "1.3.0-SNAPSHOT"]]
   :main incanter.main)


### PR DESCRIPTION
Made swank-clojure a dev dependency so incanter consumers aren't tied to a particular swank version.
Defined as a runtime dependency, the version of swank-clojure that incanter uses is obsolete and breaks consumer's used of incanter with swank.
