### PR TITLE
Header keywords in read-xls

### DIFF
--- a/modules/incanter-excel/test/incanter/excel_tests.clj
+++ b/modules/incanter-excel/test/incanter/excel_tests.clj
@@ -21,4 +21,15 @@
         (do
           (is (dataset? result))
           (is (= cols (:column-names result)))))
+     (finally (. ffile delete)))))
+
+(deftest headers
+  (let [ffile (File/createTempFile "excel-test" ".xls")
+        fname (. ffile getAbsolutePath)]
+    (try
+      (let [dset (dataset [:a :b :c]
+                          [[1 2 3]])
+            result (do (save-xls dset fname) (read-xls fname :header-keywords true))]
+        (is (dataset? result))
+        (is (= (:column-names dset) (:column-names result))))
       (finally (. ffile delete)))))


### PR DESCRIPTION
Allow the read-xls to convert the header line into keywords (easier to use in later processing).  Default behavior remains.
