### PR TITLE
Suspected row/column mixup in two sample chisq-test.

### DIFF
--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -2417,14 +2417,14 @@ Test for different variances between 2 samples
                      (second (:levels xtab)))
           r-margins (if table?
                       (if two-samp?
-                        (apply hash-map (interleave r-levels (map sum (trans table))))
+                        (apply hash-map (interleave r-levels (map sum table)))
                         (if (> (nrow table) 1)
                           (to-list table)
                           (throw (Exception. "One dimensional tables must have only a single column"))))
                       (second (:margins xtab)))
           c-margins (if table?
                       (if two-samp?
-                        (apply hash-map (interleave c-levels (map sum table)))
+                        (apply hash-map (interleave c-levels (map sum (trans table))))
                         0)
                       (first (:margins xtab)))
 
@@ -2440,7 +2440,7 @@ Test for different variances between 2 samples
                     (not (nil? freq)) (div freq (sum freq))
                     :else (repeat n (/ n))))
           E (if two-samp?
-              (for [r r-levels c c-levels]
+              (for [c c-levels r r-levels]
                 (/ (* (c-margins c) (r-margins r)) N))
               (mult N probs))
           X-sq (if (and correct (and (= (count r-levels) 2) (= (count c-levels) 2)))


### PR DESCRIPTION
chisq-test fails with a NullPointerException if you try something like:

```
         (chisq-test :table  (matrix [[1 10 1] [10 1 1]]))
```

Suspected cause is a row/column mixup when calculating the marginal values and also (secondary issue, masked by the NullPointerException) when building the expected value matrix.  Both these should be addressed by the attached patch.  Above example now succeeds and gives:

```
          :X-sq 14.727272727272727
```

...which matches chisq.test in R.
