### PR TITLE
refactor transform-col

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -1956,16 +1956,15 @@ altering later ones."
            rows (map #(merge (index (submap % right-keys)) %) (:rows right-data))]
        (to-dataset rows))))
 
-;; credit to Xavier Shay
+;; credit to M.Brandmeyer
 (defn transform-col
-" Apply function f to the specified column of data and replace the column
-  with new values."
-  [column f data] 
-  (let [new-col-names (sort-by (partial = column) (col-names data))
-        new-dataset (conj-cols
-                      (sel data :except-cols column)
-                      ($map f column data))]
-    ($ (col-names data) (col-names new-dataset new-col-names))))
+" Apply function f & args to the specified column of dataset and replace the column
+  with the resulting new values."
+  [dataset column f & args]
+  (->> (map #(apply update-in % [column] f args) (:rows dataset))
+    vec
+    (assoc dataset :rows)))
+
 
 (defn deshape
 " Returns a dataset where the columns identified by :merge are collapsed into 

--- a/modules/incanter-core/test/incanter/core_tests.clj
+++ b/modules/incanter-core/test/incanter/core_tests.clj
@@ -34,6 +34,7 @@
 (def dataset3 (dataset [:a :b :c] [{:a 1 :b 2 :c 3} {:a 4 :b 5 :c 6}]))
 (def dataset4 (dataset ["a" "b" "c"] [{"a" 1 "b" 2 "c" 3} {"a" 4 "b" 5 "c" 6}]))
 (def dataset5 (dataset ["a" "b" "c"] [{"a" 1 "b" 2 "c" 3} {"b" 5 "c" 6}]))
+(def dataset6 (dataset [:a :b :c] [[1 2 3]]))
 
 (deftest dataset-tests
   (is (= (sel dataset1 :cols :a) [1 4]))
@@ -42,10 +43,14 @@
   (is (= (sel dataset3 :cols :a) [1 4]))
   (is (= (sel dataset4 :cols :b) [2 5]))
   (is (= (sel dataset4 :cols "c") [3 6]))
-  (is (= (sel dataset5 :rows 1 :cols :a) nil)))
+  (is (= (sel dataset5 :rows 1 :cols :a) nil))
+  (is (= (sel dataset6 :cols :a) 1)))
 
-(deftest dataset-transforms
-  (is (= (transform-col :b (partial * 2) dataset1) (dataset [:a :b :c] [[1 4 3] [4 10 6]]))))
+(deftest dataset-transforms  
+  (is (= (transform-col dataset6 :b + 10) (dataset [:a :b :c] [[1 12 3]]))
+      "Single-row special case")
+  (is (= (transform-col dataset1 :b (partial + 10))) (dataset [:a :b :c] [[1 12 3] [4 15 6]]))
+  (is (= (transform-col dataset1 :b * 2) (dataset [:a :b :c] [[1 4 3] [4 10 6]]))))
 
 ;; define a simple matrix for testing
 (def A (matrix [[1 2 3] 


### PR DESCRIPTION
transform-col doesn't work for single-row datasets due to use of conj-cols, refactor implementation to not use it
