### PR TITLE
(matrix data ncol) now accepts Java arrays.

### DIFF
--- a/modules/incanter-core/src/incanter/internal.clj
+++ b/modules/incanter-core/src/incanter/internal.clj
@@ -40,7 +40,7 @@
       (Matrix. (double-array data))))
   ([data ncol]
     (cond
-      (coll? data)
+      (or (coll? data) (.isArray (class data)))
         (Matrix. (double-array data) ncol)
        (number? data)
         (Matrix. data ncol))) ; data is the number of rows in this case


### PR DESCRIPTION
e.g. now we can write (matrix (double-array 10000) 10)
TODO: we can also check if data is already of double[] type to avoid unnecessary conversions.
