### PR TITLE
Created scalar-abs-value function to improve performance

### DIFF
--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -235,10 +235,10 @@
     (is (= 1 (damerau-levenshtein-distance b c)))
     (is (= 3 (damerau-levenshtein-distance a c)))))
 
-(deftest fast-abs-test
+(deftest scalar-abs-test
   (is
     (= 9223372036854775808
-       (fast-abs -9223372036854775808))))
+       (scalar-abs -9223372036854775808))))
 
 (deftest euclid
   (is 


### PR DESCRIPTION
Improved the performance of various functions in incanter.stats by adding a scalar absolute value function to replace 'abs' in incanter.stats.

scalar-abs uses *' instead of \* in order to automatically promote numeric values.
