### PR TITLE
Hackday: Added 2 type declarations to avoid reflection and whitespace cleanup

### DIFF
--- a/modules/incanter-core/project.clj
+++ b/modules/incanter-core/project.clj
@@ -15,4 +15,3 @@
   ;;; Clojars or Maven central yet.
   :repositories {"snapshots" {:url "http://oss.sonatype.org/content/repositories/snapshots"}}
   )
-

--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -54,7 +54,7 @@
 
 (def ^{:dynamic true
        :doc "This variable is bound to a dataset when the with-data macro is used.
-              functions like $ and $where can use $data as a default argument."} 
+              functions like $ and $where can use $data as a default argument."}
      $data)
 
 (defrecord Dataset [column-names rows])
@@ -292,7 +292,7 @@
                 cols cols
                 except-cols (except-for (.columns mat) except-cols)
                 :else true)
-         mat (if (nil? filter) mat (matrix (filter filter mat)))
+         ^Matrix mat (if (nil? filter) mat (matrix (filter filter mat)))
          all-rows? (or (true? rows) (= rows :all))
          all-cols? (or (true? cols) (= cols :all))]
      (cond
@@ -373,7 +373,7 @@
 "
   ([& args]
    (reduce
-    (fn [A B] (.viewDice (bind-rows (trans A) (trans B))))
+    (fn [A B] (.viewDice ^Matrix (bind-rows (trans A) (trans B))))
     args)))
 
 
@@ -1597,7 +1597,7 @@ altering later ones."
   ([mat]
      (head 10 mat)))
 
-(defn $where 
+(defn $where
 "An alias to (query-dataset (second args) (first args)). If given only a single argument,
   it will use the $data binding for the first argument, which is set with
   the with-data macro.


### PR DESCRIPTION
Added 2 type declarations to get rid of ~6 reflection warnings in core.clj
Some whitespace cleanup.
From the London Incanter Hackday
