### PR TITLE
Fix for sample-multinomial with size 1 resulting in ISeq from Double exception

### DIFF
--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -427,13 +427,9 @@
     (let [min-val (double min)
           max-val (double max)
           dist (DoubleUniform. min-val max-val (DoubleMersenneTwister.))]
-      (if (= size 1)
-        (if integers
-          (DoubleUniform/staticNextIntFromTo min-val max-val)
-          (DoubleUniform/staticNextDoubleFromTo min-val max-val))
-        (if integers
-          (for [_ (range size)] (DoubleUniform/staticNextIntFromTo min-val max-val))
-          (for [_ (range size)] (DoubleUniform/staticNextDoubleFromTo min-val max-val)))))))
+      (if integers
+        (for [_ (range size)] (DoubleUniform/staticNextIntFromTo min-val max-val))
+        (for [_ (range size)] (DoubleUniform/staticNextDoubleFromTo min-val max-val))))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1699,7 +1695,7 @@
                (loop [samp-indices [] indices-set #{}]
                  (if (= (count samp-indices) size)
                    samp-indices
-                   (let [i (sample-uniform 1 :min 0 :max max-idx :integers true)]
+                   (let [i (first (sample-uniform 1 :min 0 :max max-idx :integers true))]
                      (if (contains? indices-set i)
                        (recur samp-indices indices-set)
                        (recur (conj samp-indices i) (conj indices-set i))))))))))))


### PR DESCRIPTION
- Evaluating (stats/sample-multinomial 1) causes the exception
  java.lang.IllegalArgumentException: Don't know how to create ISeq from:
  java.lang.Double, because sample-uniform returns a sequence if called with a
  size > 1 and a double otherwise.
- This happens because sample-uniform returns a double if called with size=1
  and a seq otherwise. The fix is to make sample-uniform always return a seq,
  even if it just has one element.
- There is only one place where sample-uniform is called with size=1 and this
  commit updates the call.
- There are two places where sample-uniform is called with size passed in as a
  parameter. One call is in a place in sample where it is always true that
  size>1. The other call is in sample-multinomial and this commit fixes the
  problem there.
