### PR TITLE
proposed fix for issue #61 (xy-plot no longer sets labels)

### DIFF
--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -1052,7 +1052,7 @@
                            (if group-by#
                              (format "%s, %s (0)" '~x '~y)
                              (format "%s, %s" '~x '~y)))
-           args# (concat [~x ~y ~create-xy-plot] (apply concat (seq (apply assoc opts#
+           args# (concat [~x ~y] (apply concat (seq (apply assoc opts#
                                                            [:group-by group-by#
                                                             :title title#
                                                             :x-label x-lab#


### PR DESCRIPTION
the parameter fn create-xy-plot is added to the argument list once in the xy-plot macro and also in the xy-plot\* function (which is called by the macro), resulting in an uneven number of entries in the opts seq - this leads to a key/value mixup in the resulting options map. in consequence, the options are not applied correctly to the xy-chart - i've removed create-xy-plot from the argument list that's being concatenated inside the xy-plot macro.

link to issue: https://github.com/liebke/incanter/issues/61
