### PR TITLE
Fix bug with quotient conversion

### DIFF
--- a/modules/incanter-core/src/incanter/symbolic.clj
+++ b/modules/incanter-core/src/incanter/symbolic.clj
@@ -32,7 +32,8 @@
 (defn- quotient? [x] (and (>= (count x) 3) (= (first x) '/)))
 
 (defn- conv-qtnt [x] "Convert a quotient to a product of a base with an inverse"
-  (list '* (second x) (list 'pow (flatten (list '* (nthnext x 2) 1)) -1)))
+  (list '* (second x) (list 'pow (list* '*  1 (nthnext x 1))) -1))
+
 ;exp can also kind of be chainrulized below, it makes sense not to though since
 ;it takes 2 args, not one.  log base whatever is same situation
 (defn- expnt [e] (nth e 2))


### PR DESCRIPTION
Only two years late - quotients are now properly converted to the product of a base and the inverse product of the rest.
