### PR TITLE
ISSUE 96: (in liebke's branch) The clojure compiler was confusing the

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -283,7 +283,7 @@
 
 
 (defmethod sel [incanter.Matrix true]
-  ([^Matrix mat & {:keys [rows cols except-rows except-cols filter]}]
+  ([^Matrix mat & {:keys [rows cols except-rows except-cols filter-fn]}]
    (let [rows (cond
                 rows rows
                 except-rows (except-for (.rows mat) except-rows)
@@ -292,7 +292,7 @@
                 cols cols
                 except-cols (except-for (.columns mat) except-cols)
                 :else true)
-         ^Matrix mat (if (nil? filter) mat (matrix (filter filter mat)))
+         ^Matrix mat (if (nil? filter-fn) mat (matrix (filter filter-fn mat)))
          all-rows? (or (true? rows) (= rows :all))
          all-cols? (or (true? cols) (= cols :all))]
      (cond


### PR DESCRIPTION
'filter' parameter with the clojure.core filter fn. I simply renamed the
argument to 'filter-fn' and updated the code using it.
