### PR TITLE
Extended incanter-latex/to-latex function, also handles datasets

### DIFF
--- a/modules/incanter-latex/src/incanter/latex.clj
+++ b/modules/incanter-latex/src/incanter/latex.clj
@@ -128,13 +128,15 @@ Example:
                                  (> (:height dimensions) 0)))
                                false
                                true)
+        hline-tex (clojure.string/join (if hline [newline hline newline] [newline ""]))
         safe-get-row (fn [mx-or-ds r] (sel mx-or-ds :rows r))
         write-row (fn [coll] (apply str (interpose " & " coll)))]
    (str
     "\\begin{" mxtype "}"
     preamble
     (when (seq col-just) (clojure.string/join (flatten ["{" col-just "}"])))
-    (clojure.string/join (if hline [newline hline newline] [newline ""]))
+    (when (seq (:column-names mx)) (clojure.string/join (flatten [hline-tex (interpose " & " (:column-names mx)) table-newline])))
+    hline-tex
     (apply
      str
      (interleave
@@ -146,7 +148,7 @@ Example:
         (range (:height dimensions))))
       (concat (drop-last (take (:height dimensions) (cycle [(clojure.string/join [table-newline newline])]))) [""])))
     (if do-table-newline-last table-newline "")
-    (clojure.string/join (if hline [newline hline newline] [newline ""]))
+    hline-tex
     "\\end{" mxtype "}")))
 
 


### PR DESCRIPTION
By using sel instead of nth to-latex now works with datasets.
I have also added some extensions that let you produce basic tables with the tabu package.
The preamble that inserts a string after the begin block is something that the R Hmisc package doesn't have, but that I use to generate my tables.
If you are interested in this then I would be happy to document the extra options and perhaps provide some examples.
If you like I could also take on the challenge of implementing the remaining functionality from the Hmisc latex function. (Basically multi-column, multi-row stuff)

All the best,
