### PR TITLE
Matrix can be printed instead of throwing error

### DIFF
--- a/modules/incanter-core/project.clj
+++ b/modules/incanter-core/project.clj
@@ -9,5 +9,5 @@
                  [org.clojure/math.combinatorics "0.0.3"
                   :exclusions [org.clojure/clojure]]
                  [net.sourceforge.parallelcolt/parallelcolt "0.10.0"]
-                 [com.quantisan/clatrix "0.2.1"]]
+                 [com.quantisan/clatrix "0.2.2"]]
   :java-source-paths ["java"])

--- a/modules/incanter-core/src/incanter/internal.clj
+++ b/modules/incanter-core/src/incanter/internal.clj
@@ -81,17 +81,3 @@
      (let [a# (if (number? ~A) (replicate (count ~B) ~A) ~A)
            b# (if (number? ~B) (replicate (count ~A) ~B) ~B)]
        (map ~op a# b#))))
-
-;; PRINT METHOD FOR COLT MATRICES
-(defmethod print-method Matrix [o, ^java.io.Writer w]
-  (let [formatter (DoubleFormatter. "%1.4f")]
-    (do
-      (.setPrintShape formatter false)
-      (.write w "[")
-      (.write w (.toString formatter o))
-      (.write w "]\n"))))
-
-
-
-
-


### PR DESCRIPTION
printing of Matrix falls back to Clatrix print-method and using Clatrix 0.2.2

output example

``` clj
incanter.core-tests=> (print A)
 A 4x3 matrix
 -------------
 1.00e+00  2.00e+00  3.00e+00 
 4.00e+00  5.00e+00  6.00e+00 
 7.00e+00  8.00e+00  9.00e+00 
 1.00e+01  1.10e+01  1.20e+01 
nil

```
