### PR TITLE
Ignore Eclipse-related files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,13 @@ pom.xml
 build
 target
 lib
+bin
 classes
 *.jar
 *.log
 .cake
 .lein*
 pom.xml.asc
+/.classpath
+/.project
+/.settings


### PR DESCRIPTION
Simple .gitignore edit to ignore Eclipse related files when used in Eclipse with the Counterclockwise plugin.
