### PR TITLE
Matrix construction from arrays

### DIFF
--- a/modules/incanter-core/src/incanter/internal.clj
+++ b/modules/incanter-core/src/incanter/internal.clj
@@ -39,7 +39,9 @@
      (coll? (first data))
       (clx/matrix data)
      (number? (first data))
-      (clx/matrix (map vector data))))
+      (clx/matrix (map vector data))
+     :default
+      (clx/matrix (map seq data))))
   ([data ncol]
    {:pre [(number? (first data))]}
    (let [chunked  (partition ncol data)]

--- a/modules/incanter-core/test/incanter/core_tests.clj
+++ b/modules/incanter-core/test/incanter/core_tests.clj
@@ -81,7 +81,10 @@
 ;; constructing matrices from arrays
 (deftest matrix-from-arrays
   (is (= (matrix [1.0 2.0 3.0]) (matrix (double-array [1.0 2.0 3.0]))))
-  (is (= (matrix [1.0 2.0 3.0]) (matrix (long-array [1 2 3])))))
+  (is (= (matrix [1.0 2.0 3.0]) (matrix (long-array [1 2 3]))))
+  (is (= (matrix [[1 2] [3 4]]) 
+         (matrix (object-array [(double-array [1.0 2.0])
+                                (double-array [3.0 4.0])])))))
 
 
   ;; performing clojure sequence operations on matrices


### PR DESCRIPTION
Simple patch to allow and test matrix construction from Java arrays, and arrays of arrays.  Generally useful for Java interop. 
