### PR TITLE
Finish funciton plots strictly on max-range value.

### DIFF
--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -322,6 +322,10 @@
     x
     [x]))
 
+(defn- range-inclusive [start end step]
+  "Similar to range but adds end to result."
+  (concat (range start end step) [end]))
+
 (defn add-histogram*
   ([chart x & options]
     (let [opts (when options (apply assoc {} options))
@@ -645,7 +649,7 @@
     (let [opts (when options (apply assoc {} options))
            step-size (or (:step-size opts)
                          (float (/ (- max-range min-range) 500)))
-           x (range min-range (+ step-size max-range) step-size)
+           x (range-inclusive min-range max-range step-size)
            series-lab (or (:series-label opts)
                           (format "%s" 'function))]
        (add-lines chart x (map function x) :series-label series-lab))))
@@ -713,7 +717,7 @@
     (let [opts (when options (apply assoc {} options))
           step-size (or (:step-size opts)
                         (float (/ (- max-range min-range) 500)))
-          t (range min-range (+ step-size max-range) step-size)
+          t (range-inclusive min-range max-range step-size)
           [x y] (apply map vector (map function t))
           series-lab (or (:series-label opts)
                          (format "%s" 'function))]
@@ -2369,7 +2373,7 @@
   ([function min-range max-range & options]
    (let [opts (when options (apply assoc {} options))
          step-size (or (:step-size opts) (float (/ (- max-range min-range) 500)))
-         _x (range min-range (+ step-size max-range) step-size)
+         _x (range-inclusive min-range max-range step-size)
          title (or (:title opts) "")
          x-lab (or (:x-label opts) (format "%s < x < %s" min-range max-range))
          y-lab (or (:y-label opts) (str 'function))
@@ -2437,7 +2441,7 @@
   ([function min-range max-range & options]
    (let [opts (when options (apply assoc {} options))
          step-size (or (:step-size opts) (float (/ (- max-range min-range) 500)))
-         _t (range min-range (+ step-size max-range) step-size)
+         _t (range-inclusive min-range max-range step-size)
          [_x _y] (apply map vector (map function _t))
          title (or (:title opts) "")
          x-lab (or (:x-label opts) (format "%s < x < %s" (apply min _x) (apply max _x)))


### PR DESCRIPTION
My first change was a bit broken. E.g. if we draw function with `min-range = 4` and `max-range = 38` then last drawing point was `38.00000184774399`. It may cause problem because some functions may not be defined outside specific range: [4, 38] in our case.  
In this commit I explicitly add `max-range` to list of values instead of using `(+ step-size max-range)` as upper bound.
