### PR TITLE
fixes #119 linear-model not correctly computing t-probs

### DIFF
--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -2088,11 +2088,11 @@
           f-stat (/ msr mse)
           df1 p-1
           df2 (- n p)
-          f-prob (cdf-f f-stat :df1 df1 :df2 df2 :lower-tail false)
+          f-prob (cdf-f f-stat :df1 df1 :df2 df2 :lower-tail? false)
           coef-var (mult mse xtxi)
           std-errors (sqrt (diag coef-var))
           t-tests (div coefs std-errors)
-          t-probs (mult 2 (cdf-t (abs t-tests) :df df2 :lower-tail false))
+          t-probs (mult 2 (cdf-t (abs t-tests) :df df2 :lower-tail? false))
           t-95 (mult (quantile-t 0.975 :df df2) std-errors)
           coefs-ci (if (number? std-errors)
                        [(plus coefs t-95)


### PR DESCRIPTION
there's things more elegant than clojure's treatment of keyword arguments...

was:

```
=> (:t-probs (linear-model [-1 1 3 0] [2 3 -1 0]))
A 2x1 matrix
-------------
1.65e+00
1.53e+00
```

is:

```
=> (:t-probs (linear-model [-1 1 3 0] [2 3 -1 0]))
A 2x1 matrix
-------------
3.55e-01
4.65e-01
```
