### PR TITLE
fix column names when constructing a dataset from a map

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -1392,7 +1392,7 @@ http://en.wikipedia.org/wiki/Cholesky_decomposition
                  (map? obj)
                    ;; see if any of the values are collections
                    (if (reduce #(or %1 %2) (map coll? (vals obj)))
-                     (vals obj)
+                     (trans (vals obj))
                      [(vals obj)])
                    (coll? obj)
                      (cond

--- a/modules/incanter-core/test/incanter/core_tests.clj
+++ b/modules/incanter-core/test/incanter/core_tests.clj
@@ -50,6 +50,11 @@
   (is (= (sel dataset5 :rows 1 :cols :a) nil))
   (is (= (sel dataset6 :cols :a) 1)))
 
+(def map1 {:col-0 [1.0 2.0 3.0] :col-1 [4.0 5.0 6.0]})
+
+(deftest dataset-construction
+  (is (= (to-dataset map1) (to-dataset [[1.0 4.0][2.0 5.0][3.0 6.0]]))))
+
 (deftest dataset-transforms
   (is (= (transform-col dataset6 :b + 10) (dataset [:a :b :c] [[1 12 3]]))
       "Single-row special case")


### PR DESCRIPTION
column names were mixed up when constructing a dataset from
a map, this has been fixed by introducting a transpose
