### PR TITLE
Return permutation matrix in LU decomposition.

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -921,15 +921,17 @@ http://en.wikipedia.org/wiki/Cholesky_decomposition
     a map containing:
       :L -- the lower triangular factor
       :U -- the upper triangular factor
+      :P -- the permutation matrix
 
   References:
     http://en.wikipedia.org/wiki/LU_decomposition
-    http://incanter.org/docs/parallelcolt/api/cern/colt/matrix/tdouble/algo/decomposition/DoubleLUDecomposition.html
+    http://mikiobraun.github.io/jblas/javadoc/org/jblas/Decompose.LUDecomposition.html
 "
   ([mat]
     (let [result (clx/lu mat)]
       {:L (:l result)
-       :U (:u result)})))
+       :U (:u result)
+       :P (:p result)})))
 
 (defn vector-length [u]
   (sqrt (reduce + (map (fn [c] (pow c 2)) u))))

--- a/modules/incanter-core/test/incanter/core_tests.clj
+++ b/modules/incanter-core/test/incanter/core_tests.clj
@@ -486,6 +486,10 @@
     ;(check :full    expect-full)
     ;(check :compact expect-compact)))
 
+(deftest decomp-lu-test
+  (let [m (matrix [[0 1 2] [3 3 2] [4 0 1]])
+        {:keys [L U P]} (decomp-lu m)]
+    (is (= m (mmult P L U)))))
 
 (deftest test-metadata
   (let [md {:name "metadata test"}


### PR DESCRIPTION
Current LU decomposition implementation is useless without permutation matrix P because  A = L_U is incorrect, correct formula: A = P_L*U: [LU decomposition](http://en.wikipedia.org/wiki/Lu_decomposition) 
