### PR TITLE
Fix for issue #149 - DivideByZero exception in linear model

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -495,6 +495,20 @@
                (clx/div (double 1) (first args))
                (reduce clx/div (pass-to-matrix args)))))
 
+(defn safe-div  ;; TODO modify to work with matrices ?
+  "DivideByZero safe alternative to clojures / function,
+   detects divide by zero and returns Infinity, -Infinity or NaN as appropriate.
+   Note: Does not work on matrices, only primitive types"
+  ([x] (safe-div 1 x))
+  ([x y]
+     (try (/ x y)
+          (catch ArithmeticException _
+            (cond (> x 0)   Double/POSITIVE_INFINITY
+                  (zero? x) Double/NaN
+                  :else     Double/NEGATIVE_INFINITY))))
+  ([x y & more]
+     (reduce safe-div (safe-div x y) more)))
+
 
 (defn pow  ;; TODO use jblas and fix meta
   " This is an element-by-element exponent function, raising the first argument

--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -41,7 +41,7 @@
                               gamma pow sqrt diag trans regularized-beta ncol
                               nrow identity-matrix decomp-cholesky decomp-svd
                               matrix length log10 sum sum-of-squares sel matrix?
-                              cumulative-sum solve vectorize bind-rows)]))
+                              cumulative-sum solve vectorize bind-rows safe-div)]))
 
 (defn scalar-abs
   "Fast absolute value function"
@@ -2078,14 +2078,14 @@
           sse (sum-of-squares resid)
           ssr (sum-of-squares (minus fitted (mean fitted)))
           sst (+ sse ssr)
-          r-square (/ ssr sst)
+          r-square (safe-div ssr sst)
           n (nrow y)
           p (ncol _x)
           p-1 (if intercept (dec p) p)
           adj-r-square (- 1 (* (- 1 r-square) (/ (dec 1) (- n p 1))))
-          mse (/ sse (- n p))
-          msr (/ ssr p-1)
-          f-stat (/ msr mse)
+          mse (safe-div sse (- n p))
+          msr (safe-div ssr p-1)
+          f-stat (safe-div msr mse)
           df1 p-1
           df2 (- n p)
           f-prob (cdf-f f-stat :df1 df1 :df2 df2 :lower-tail? false)

--- a/modules/incanter-core/test/incanter/core_tests.clj
+++ b/modules/incanter-core/test/incanter/core_tests.clj
@@ -575,3 +575,21 @@
   (is (factorial 0) 1.0)
   (is (thrown? AssertionError (factorial -1))))
 
+
+(deftest safe-div-test
+  (is 1/2 (safe-div 2))
+  (is 2 (safe-div 10 5))
+  (is 2 (safe-div 20 2 5))
+
+  (is -1/2 (safe-div -2))
+  (is -2 (safe-div -10 5))
+  (is -2 (safe-div -20 2 5))
+
+  (is Double/NaN (safe-div 0))
+  (is Double/NaN (safe-div 0 0))
+  (is Double/NaN (safe-div 0 0 5))
+  (is Double/POSITIVE_INFINITY (safe-div 10 0))
+  (is Double/POSITIVE_INFINITY (safe-div 20 2 2 0))
+  (is Double/POSITIVE_INFINITY (safe-div 20 0 2 2))
+  (is Double/NEGATIVE_INFINITY (safe-div -10 0))
+  (is Double/NEGATIVE_INFINITY (safe-div -10 5 0)))

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -334,3 +334,9 @@
     (is
       (= (format "%.8f" 5.4456385557467595) 
          (format "%.8f" (:X-sq (benford-test coll)))))))
+
+(deftest linear-model-with-zero-ss
+  ;; pre 1.5.0 linear model would have a divide by zero exception with this data
+  (let [data [0.0 2.0 0.0 0.0 0.0 1.0 1.0 3.0 0.0 2.0 0.0 1.0 2.0 0.0 0.0 0.0 0.0 1.0 2.0 0.0 1.0 1.0]
+        lm (linear-model data data)]
+    (is 1.0 (:r-square lm))))


### PR DESCRIPTION
Provides a safe-div function in core that handles division by zero for primitive types and updates linear-model to use it
