### PR TITLE
add incanter-svg module to export SVG charts

### DIFF
--- a/modules/incanter-svg/.gitignore
+++ b/modules/incanter-svg/.gitignore
@@ -1,0 +1,4 @@
+pom.xml
+*jar
+lib
+classes

--- a/modules/incanter-svg/project.clj
+++ b/modules/incanter-svg/project.clj
@@ -1,0 +1,15 @@
+(defproject incanter/incanter-svg "1.5.0-SNAPSHOT"
+  :description "Incanter-svg is the SVG module of the Incanter project."
+  :url "http://incanter.org/"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :scm {:name "git" :url "https://github.com/liebke/incanter"}
+  :min-lein-version "2.0.0"
+  :dependencies [[incanter/incanter-charts "1.5.0-SNAPSHOT"]
+                 [org.clojure/clojure "1.5.1"]
+                  [org.apache.xmlgraphics/batik-dom "1.7"]
+                  [org.apache.xmlgraphics/batik-svggen "1.7"]
+                  [org.apache.xmlgraphics/batik-awt-util "1.7"]
+                  [org.apache.xmlgraphics/batik-util "1.7"]
+                  [org.apache.xmlgraphics/batik-xml "1.7"]]
+  )

--- a/modules/incanter-svg/src/incanter/svg.clj
+++ b/modules/incanter-svg/src/incanter/svg.clj
@@ -1,0 +1,52 @@
+(ns
+^{:doc "This library currently has only a single function, save-svg, which saves
+  charts as an SVG file. To build this namespace make sure the you have the Batik
+  library (http://xmlgraphics.apache.org/batik) as a declared dependency in your pom.xml or
+  project.clj file:
+  [org.apache.xmlgraphics/batik-dom \"1.7\"]
+  [org.apache.xmlgraphics/batik-svggen \"1.7\"]
+  [org.apache.xmlgraphics/batik-awt-util \"1.7\"]
+  [org.apache.xmlgraphics/batik-util \"1.7\"]
+  [org.apache.xmlgraphics/batik-xml \"1.7\"]]"}
+
+  incanter.svg
+  (:use (incanter charts))
+  (:import (java.io File FileOutputStream OutputStreamWriter)
+           (java.awt Rectangle)
+           (org.apache.batik.dom GenericDOMImplementation)
+           (org.apache.batik.svggen SVGGraphics2D)))
+
+;; Adapted from Java code at: http://dolf.trieschnigg.nl/jfreechart
+(defn save-svg
+" Save a chart object as an SVG document.
+
+  Arguments:
+    chart
+    filename
+
+  Options:
+    :width (default 500)
+    :height (default 400)
+
+  Examples:
+
+    (use '(incanter core charts svg))
+    (save-svg (function-plot sin -4 4) \"./svg-chart.svg\")
+
+
+"
+  ([chart filename & {:keys [width height ] :or {width 500 height 400}}]
+     (let [domImpl (GenericDOMImplementation/getDOMImplementation)
+           document (.createDocument domImpl nil "svg" nil)
+           svgGenerator (SVGGraphics2D. document)
+           bounds (Rectangle. width height)
+           svgFile (File. filename)
+           outputStream (FileOutputStream. svgFile)
+           out (OutputStreamWriter. outputStream "UTF-8")]
+       (do
+         (.draw chart svgGenerator bounds)
+         (.stream svgGenerator out true)
+         (.flush outputStream)
+         (.close outputStream)))))
+
+

--- a/modules/incanter-svg/test/incanter_svg/svg_tests.clj
+++ b/modules/incanter-svg/test/incanter_svg/svg_tests.clj
@@ -1,0 +1,4 @@
+(ns incanter.pdf
+  (:use [incanter.svg])
+  (:use [clojure.test]))
+

--- a/script/test
+++ b/script/test
@@ -13,7 +13,7 @@ cd "$TOP_DIR"
 RESULTS=0
 
 cd modules
-for i in core io charts mongodb pdf latex excel zoo sql; do
+for i in core io charts mongodb pdf svg latex excel zoo sql; do
     if [ -d "incanter-$i" -a -f "incanter-$i/project.clj" ] ; then
         echo "testing in incanter-$i"
         OLDWD=`pwd`


### PR DESCRIPTION
This is an incanter module to support writing charts to SVG files. The function is called save-svg and has the same parameters as save-pdf.
