### PR TITLE
Fix for minus operation for a single argument

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -435,8 +435,7 @@
   (minus 2 [1 2 3])
   (minus [1 2 3])
   "
-  [& args] (reduce clx/- (pass-to-matrix args)))
-
+  [& args] (apply clx/- (pass-to-matrix args)))
 
 
 (defn mult

--- a/modules/incanter-core/test/incanter/core_tests.clj
+++ b/modules/incanter-core/test/incanter/core_tests.clj
@@ -439,7 +439,13 @@
   (is (= (minus [1.0 2.0 3.0] [1.0 2.0 3.0]) (matrix [0 0 0])))
   (is (= (minus [1.0 2.0 3.0] 1) (matrix [0 1 2])))
   (is (= (minus 1 [1.0 2.0 3.0]) (matrix [0 -1 -2])))
-  (is (= (minus [1 2 3] (matrix [1 2 3]) (matrix [0 0 0])))))
+  (is (= (minus [1 2 3] (matrix [1 2 3]) (matrix [0 0 0]))))
+  (is (= (minus 1) -1))
+  (is (= (minus [1.0 2.0 3.0]) (matrix [-1.0 -2.0 -3.0])))
+  (is (= (minus A) (matrix [[-1 -2 -3]
+                            [-4 -5 -6]
+                            [-7 -8 -9]
+                            [-10 -11 -12]]))))
 
 (deftest matrix-mult-tests
   ;; element by element multiplication on matrices


### PR DESCRIPTION
Addresses issue #195.
1) Changed the reduce to apply. reduce will work if we provide a initial value of 0 (zero matrix when appropriate), this however might be a more expensive solution.
2) Added 3 more unit tests for this case.
3) Performance is virtually identical before and after changes:
MBP 2.4GHz w 16GB DDR3
# Before:

(time (dotimes [_ 10000](matrix-minus-test)))
## "Elapsed time: 1833.263 msecs"
# After:

(time (dotimes [_ 10000](matrix-minus-test)))
## "Elapsed time: 1831.696 msecs"
