### PR TITLE
Add support for skipping commented lines in data files with read.dataset

### DIFF
--- a/modules/incanter-io/src/incanter/io.clj
+++ b/modules/incanter-io/src/incanter/io.clj
@@ -50,9 +50,10 @@
       :compress-delim (default true if delim = \\space, false otherwise) means
                       compress multiple adjacent delimiters into a single delimiter.
       :empty-field-value (default nil) indicates the interpretation of an empty field.
+      :comment-char (default nil) skip commented lines (\"#\", \"%\", \";\", etc)
   "
 
-  [filename & {:keys [delim keyword-headers quote skip header compress-delim empty-field-value]
+  [filename & {:keys [delim keyword-headers quote skip header compress-delim empty-field-value comment-char]
                :or {delim \, quote \" skip 0 header false keyword-headers true}}]
 
   (let [compress-delim? (or compress-delim (= delim \space))
@@ -60,8 +61,8 @@
                             (fn [line] (filter #(not= % "") line))
                             identity)
         comment-char-fn (fn [line]
-                          (if (boolean (seq line))
-                            (if (.startsWith (first line) "%")
+                          (if (and (boolean (seq line)) comment-char)
+                            (if (.startsWith (first line) comment-char)
                               '()
                               line)
                             line))


### PR DESCRIPTION
I have added functionality for skipping commented lines when using read.dataset. This is a common functionality, and is the default behavior in both R (see the comment.char option in the read.table family of functions) and Matlab (see the function load(filename.dat, '-ascii')). I have added the option :comment-char to read.dataset to enable the same functionality. I have set the default to nil, which preserves read.dataset's existing behavior. By setting it to a string (e.g., "#", "%", etc.), lines in the data file beginning with that character are skipped. I'm not wedded to any of these defaults, but some method of skipping commented lines would be very helpful as I routinely process data files that have embedded meta data in the form of comments.

Let me know what you think or if the default behavior should be changed in some fashion--- for example, perhaps the value of :comment-char should be a symbol (e.g., #, \%) instead of a string?

FYI, I didn't add any new tests for this functionality, but the existing io tests still pass.

Thanks!
Nick
