### PR TITLE
Simplify read-dataset

### DIFF
--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -416,7 +416,7 @@
 
   Examples:
 
-    (use '(incanter core charts stats))
+    (use '(incanter core charts stats datasets))
     (doto (box-plot (sample-normal 1000) :legend true)
           view
           (add-box-plot (sample-normal 1000 :sd 2))
@@ -1335,10 +1335,11 @@
 
   Examples:
 
-    (use '(incanter core stats charts chrono))
+    (use '(incanter core stats charts))
+    (require '[clj-time.core :refer [date-time]])
 
     ;; plot numbers against years starting with 1900
-    (def dates (map #(-> (joda-date (+ 1900 %) 1 1 12 0 0 0 (time-zone 0))
+    (def dates (map #(-> (date-time (+ 1900 %))
                          .getMillis)
                     (range 100)))
     (def y (range 100))
@@ -3311,7 +3312,8 @@
     (view (bland-altman-plot x1 x2))
 
     (with-data (get-dataset :flow-meter)
-      (view (bland-altman-plot \"Wright 1st PEFR\" \"Mini Wright 1st PEFR\")))
+      (view (bland-altman-plot (keyword \"Wright 1st PEFR\")
+                               (keyword \"Mini Wright 1st PEFR\"))))
 
 
 

--- a/modules/incanter-io/src/incanter/datasets.clj
+++ b/modules/incanter-io/src/incanter/datasets.clj
@@ -178,11 +178,11 @@
   ([dataset-key & {:keys [incanter-home from-repo]
                    :or {incanter-home (or (System/getProperty "incanter.home")
                                           (System/getenv "INCANTER_HOME"))
-                        from-repo true}}]
+                        from-repo false}}]
      (when-let [ds (**datasets** dataset-key)]
-       (let [filename (if (or (nil? incanter-home) from-repo)
-                        (str **datasets-base-url** (ds :filename))
-                        (str incanter-home "/" (ds :filename)))
+       (let [filename (if (and (not from-repo) (not (nil? incanter-home)))
+                        (str incanter-home "/" (ds :filename))
+                        (str **datasets-base-url** (ds :filename)))
              delim (ds :delim)
              header (ds :header)]
          (read-dataset filename :delim delim :header header)))))

--- a/script/test
+++ b/script/test
@@ -9,6 +9,8 @@ fi
 
 TOP_DIR=`dirname $0`/..
 cd "$TOP_DIR"
+INCANTER_HOME=`pwd`
+export INCANTER_HOME
 
 RESULTS=0
 


### PR DESCRIPTION
Removes most options from read-dataset and introduce header, row, and dataset options that operate on the column headers, rows, and the full sequence of rows respectively.

**Justification:**
If new options are always added for a specific scenario, the list will grow unwieldy and it will be difficult to change options not knowing how it will affect other options. In my opinion there is no need to add unneeded complexity to the function for every possible scenario.

We can invert the process, strip out all the options (leaving just a few universally accepted defaults) and have the user pass in functions to manipulate the headers, rows, and collection respectively. This should leave the function clean, and users can specify and behavior they need by passing in the functions. If a user need specific functionality, new helper/utility functions can be added. This also has the advantage of building up a library of commonly used functions that can be composed and easily used to achieve any desired behavior, no matter how complicated. The inspiration comes from using http://clojure.github.io/java.jdbc/#clojure.java.jdbc/query.
- You can transform a column to a number by passing in a row-fn which does just that.
- Read in files too large for RAM? sample using dataset-fn.
- Remove lines with comments? pass in function to dataset-fn
- Column names as lowercase keywords? use :header-fn (comp keyword clojure.string/upper-case)

For example: To remove all lines beginning with "#". Pull request https://github.com/liebke/incanter/pull/219

``` clojure
(defn comment?
  "True if first element of coll begins with s"
  [s row]
  (.startsWith (first row) s))

(read-dataset (java.clojure.io/reader "file-with-comments.csv")
                       :dataset-fn #(remove (partial comment? "#") %))
```

Say you want your headers to be keywords, empty fields converted to :NA, and to sample only 10% of a huge file.

``` clojure
(defn sample-percent
  "Function take from Clojure Data Analysis Cookbook"
  [k coll]
  (filter (fn [_] (<= (rand) k)) coll))

(io/read-dataset (java.clojure.io/reader "large-file.csv")
                          :header true
                          :header-fn keyword
                          :row-fn (fn [row] (map #(if (clojure.string/blank? %) :NA %) row))
                          :dataset-fn (partial sample-percent 0.10))  
```

I tried to make small changes so you can cherry pick what is needed.
The first commit makes the change to data.csv and the first few are backward compatible changes
The last commit refactors the whole function and adds unit tests with examples of usage.
