### PR TITLE
read-dataset bug with numbers in header fixed

### DIFF
--- a/modules/incanter-io/src/incanter/io.clj
+++ b/modules/incanter-io/src/incanter/io.clj
@@ -85,7 +85,9 @@
         dataset-body (if header (rest parsed-data) parsed-data)
         column-names-strs
           (map (fn [hr-entry idx]
-                 (or hr-entry (str "col" idx)))
+                 (if hr-entry
+                   (str hr-entry)
+                   (str "col" idx)))
                (concat header-row (repeat nil))
                (range column-count))
         column-names (map (if keyword-headers keyword identity) column-names-strs)


### PR DESCRIPTION
Currently, if the header cell in csv contains only digits, appropriate column name will be nil in the dataset.
