### PR TITLE
Fixed plots legend on group-by when repeated rows for the legend column are present.

### DIFF
--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -1137,7 +1137,7 @@
                              (nth y-groups i)
                              :series-label (cond
                                              _group-by
-                                               (nth _group-by i)
+                                               (nth (reduce #(if (< (.indexOf %1 %2) 0) (conj %1 %2) %1) [] _group-by) i)
                                              series-lab
                                                series-lab
                                              :else


### PR DESCRIPTION
This was only partially fixed by 3c6ab78c5c63799d603ea51d56861f34d68502e9.
