### PR TITLE
Improved add-line function 

### DIFF
--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -67,6 +67,7 @@
                                          StandardXYBarPainter)
             (org.jfree.ui TextAnchor RectangleInsets RectangleEdge)
             (org.jfree.chart.title TextTitle)
+            (org.jfree.data UnknownKeyException)
             (org.jfree.chart.annotations XYPointerAnnotation
                                          XYTextAnnotation
                                          XYPolygonAnnotation)))
@@ -340,6 +341,26 @@
   [start end step]
   (concat (range start end step) [end]))
 
+(defn remove-series
+  "Remove an existing series speicified by series-lab.
+   If the series does not exist it return nil"
+  [chart series-label]
+  (let [data-set (-> chart .getPlot .getDataset)
+        series   (try (.getSeries data-set series-label)
+                      (catch UnknownKeyException e nil))]
+    (when series
+      (.removeSeries data-set series)
+      chart)))
+
+(defn has-series?
+  "Test to see if a chart has a series name series-lab"
+  [chart series-label]
+  (try
+    (-> chart .getPlot .getDataset (.getSeries series-label))
+    true
+    (catch UnknownKeyException e
+      false)))
+
 (defn add-histogram*
   ([chart x & options]
     (let [opts (when options (apply assoc {} options))
@@ -553,6 +574,31 @@
         (.setDataset n data-set)
         (.setRenderer n line-renderer))
       chart)))
+
+(defn extend-line
+  " Add new data set to an exiting series if it already exists,
+    otherwise, data set will be added to a newly created series. "
+  [chart x y & options]
+  (let [opts       (when options (apply assoc {} options))
+        data       (or (:data opts) $data)
+        _x         (data-as-list x data)
+        _y         (data-as-list y data)
+        series-lab (or (:series-label opts) (format "%s, %s" 'x 'y))
+        data-set   (-> chart .getPlot .getDataset)
+        series     (try (.getSeries data-set series-lab)
+                        (catch UnknownKeyException e
+                          (let [new-series    (XYSeries. series-lab (:auto-sort opts true))
+                                ;; line-renderer (XYLineAndShapeRenderer. true (true? (:points opts)))
+                                ]
+                            (.addSeries data-set new-series)
+                            new-series)))]
+    (dorun
+     (map (fn [x y]
+            (if (and (not (nil? x))
+                     (not (nil? y)))
+              (.add series (double x) (double y))))
+          _x _y))
+    chart))
 
 ;; doesn't work
 (defmethod add-lines* org.jfree.data.statistics.HistogramDataset


### PR DESCRIPTION
I just feel that the currently add-line function does not do what it's supposed to do correctly. For example, if I want to add some new data points to an existing series, there is no way to do this. New data points will always be treated as a new series, therefore, get marked with different color. It's nice to see the new addition, but when I have multiple sets of data and and want to add more points to each one of them, it just gets messy. Also from the legend of the plot we can see that even if you name your new data set as the same name with the previous one, it will still be treated as a new series. 

I added an "extend-line" function, that has what I believe the correct behavior, i.e. if you add a new data set with label which exists already, that data set will be added to the existing series, otherwise, they will be added to an newly created series. I also addd a couple help functions, that can check if a series exists or remove it. 

Feel free to let me know what you think about this change. 

Thanks
Ritchie