### PR TITLE
sel returns dataset when :rows :all specified

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -1377,18 +1377,18 @@
                  except-rows (except-for (nrow data) except-rows)
                  :else true)
           cols (cond
-
                  cols cols
                  except-cols (except-for-cols data except-cols)
                  all all
                  :else true)
+          all-rows? (or (true? rows) (= rows :all) all)
           colnames (:column-names data)
           selected-cols (cond
                           (or (= cols :all) (true? cols)) colnames
                           (coll? cols) (map #(get-column-id data %) cols)
                           :else [cols])
           selected-rows (cond
-                          (or (= rows :all) (true? rows) all)
+                          all-rows?
                             (:rows data)
                           (number? rows)
                             (list (nth (:rows data) rows))
@@ -1401,11 +1401,10 @@
           (if (= (count result) 1)
             (ffirst result)
             (mapcat identity result))
-        (and (= (count result) 1) (not (or (coll? rows) (true? rows))))
+        (and (= (count result) 1) (not (or (coll? rows) all-rows?)))
           (first result)
         :else
           (dataset selected-cols (map #(apply assoc {} (interleave selected-cols %)) result))))))
-
 
 (defn to-dataset
   "

--- a/modules/incanter-core/test/incanter/core_tests.clj
+++ b/modules/incanter-core/test/incanter/core_tests.clj
@@ -54,6 +54,7 @@
   (is (= (sel dataset4 :cols "c") [3 6]))
   (is (= (sel dataset5 :rows 1 :cols :a) nil))
   (is (= (sel dataset6 :cols :a) 1))
+  (is (= (sel dataset6 :cols [:a] :rows :all) (dataset [:a] [[1 2 3]])))
   (is (= (sel (dataset [:a :b] [[11 12]]) :except-cols :b) (dataset [:a] [[11]]))))
 
 (def map1 {:col-0 [1.0 2.0 3.0] :col-1 [4.0 5.0 6.0]})


### PR DESCRIPTION
Before the fix a simple list was returned for datasets with a single row
when `:cols :all :rows :all` was used with `incanter.core/sel`. Although `sel` is supposed to return
simple lists only when at least one of the query params `:rows`and `:cols`
is an atomic object (index or name).

Fixes issue #235
