### PR TITLE
Calling kurtosis correctly with SD instead of variance

### DIFF
--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -1616,8 +1616,6 @@
     (let [xx (sort (to-list x))]
       (DoubleDescriptive/median (DoubleArrayList. (double-array xx))))))
 
-
-
 (defn kurtosis
   "
   Returns the kurtosis of the data, x. \"Kurtosis is a measure of the \"peakedness\"
@@ -1634,7 +1632,7 @@
     http://incanter.org/docs/parallelcolt/api/cern/jet/stat/tdouble/DoubleDescriptive.html
     http://en.wikipedia.org/wiki/Kurtosis
   "
-  ([x] (DoubleDescriptive/kurtosis (DoubleArrayList. (double-array x)) (mean x) (variance x))))
+  ([x] (DoubleDescriptive/kurtosis (DoubleArrayList. (double-array x)) (mean x) (sd x))))
 
 
 

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -119,6 +119,35 @@
   ;; calculate the median of a variable
   (is (= (median x) 113.0)))
 
+(deftest kurtosis-test
+  (let [test-sample [2.00 2.00 2.00 2.00 2.00
+                     2.00 2.00 2.00 2.00 2.00
+                     2.00 2.00 2.00 2.00 2.00
+                     2.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 3.00 3.00 3.00
+                     3.00 3.00 4.00 4.00 4.00
+                     4.00 4.00 4.00 4.00 4.00
+                     4.00 4.00 4.00 4.00 4.00
+                     4.00 4.00 4.00 4.00 2.00]]
+    (testing "correctness of result"
+      (is (= -0.11735294117647133 (kurtosis test-sample))))
+    (testing "invariance of calculation"
+      (let [kurtosis-diff (- (kurtosis (map (partial * 10) test-sample))
+                            (kurtosis test-sample))]
+        (is (< kurtosis-diff 1e-15))))
+    ))
+
 (deftest sample-tests
   ;; test sample function
   (is (not= (sample (range 10) :replacement false) (range 10)))


### PR DESCRIPTION
`DoubleDescriptive/kurtosis` was getting called with variance instead of standard deviation.

After changing this to use `sd` it returns the correct value for data from #226, wich is  -0.11735294117647133. The same value gets calculated with R package e1071, using the fourth central moment and sample standard deviation formula (see http://www.r-tutor.com/elementary-statistics/numerical-measures/kurtosis).

Furthermore `kurtosis` is invariant against multiplication with a constant.

Both scenarios were added as tests.

Fixes github issue #226
