### PR TITLE
Update median to return Double/NaN when provided an empty list

### DIFF
--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -1614,7 +1614,10 @@
   "
   ([x]
     (let [xx (sort (to-list x))]
-      (DoubleDescriptive/median (DoubleArrayList. (double-array xx))))))
+      (if (empty? xx)
+        Double/NaN
+        (DoubleDescriptive/median (DoubleArrayList. (double-array xx)))))))
+
 
 (defn kurtosis
   "

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -117,7 +117,8 @@
 
 (deftest median-test
   ;; calculate the median of a variable
-  (is (= (median x) 113.0)))
+  (is (= (median x) 113.0))
+  (is (Double/isNaN (median []))))
 
 (deftest kurtosis-test
   (let [test-sample [2.00 2.00 2.00 2.00 2.00


### PR DESCRIPTION
median in stats.clj currently returns 0.0 for when provided an empty list.
the median of nothing is undefined and as such should return Double/NaN. 

I have updated the function for median and it's test to follow this logic.
