### PR TITLE
Melt with multiple pivot keys

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -2298,21 +2298,24 @@
 (defn melt
   "
   Melt an object into a form suitable for easy casting, like a melt function in R.
-  Only accepts one pivot key for now. e.g.
+  It accepts multiple pivot keys (identifier variables that are reproduced for each
+  row in the output).
 
     (use '(incanter core charts datasets))
     (view (with-data (melt (get-dataset :flow-meter) :Subject)
               (line-chart :Subject :value :group-by :variable :legend true)))
 
   See http://www.statmethods.net/management/reshape.html for more examples."
-  [dataset pivot-key]
+  [dataset & pivot-keys]
   (let [in-m (to-map dataset)
         nrows (nrow dataset)
         ks (keys in-m)]
     (to-dataset
-     (for [k ks i (range nrows) :when (not (= pivot-key k))]
-       (zipmap [pivot-key :variable :value]
-               [(nth (pivot-key in-m) i) k (nth (k in-m) i)])))))
+     (for [k ks i (range nrows) :when (not-any? #(= k %) pivot-keys)]
+       (zipmap (conj pivot-keys :variable :value)
+               (conj (map #(nth (% in-m) i) pivot-keys)
+                     k
+                     (nth (k in-m) i)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; CATEGORICAL VARIABLES

--- a/modules/incanter-core/test/incanter/dataset_tests.clj
+++ b/modules/incanter-core/test/incanter/dataset_tests.clj
@@ -88,14 +88,14 @@
 
 (deftest melt-test
   (testing "Melting the data")
-  (let [dset (dataset  [:id :time :x1 :x2 ]
-                       [[1 1 5 6]
-                        [2 2 7 8]])
-        expected (dataset [:value :variable :id]
-                          [[1 :time 1]
-                           [2 :time 2]
-                           [5 :x1 1]
-                           [7 :x1 2]
-                           [6 :x2 1]
-                           [8 :x2 2]])]
-    (is (= (melt dset :id) expected))))
+  (let [dset (dataset  [:id :another-id :time :x1 :x2 ]
+                       [[1 3 1 5 6]
+                        [2 4 2 7 8]])
+        expected (dataset [:value :variable :id :another-id]
+                          [[1 :time 1 3]
+                           [2 :time 2 4]
+                           [5 :x1 1 3]
+                           [7 :x1 2 4]
+                           [6 :x2 1 3]
+                           [8 :x2 2 4]])]
+    (is (= (melt dset :id :another-id) expected))))


### PR DESCRIPTION
Modify the melt function so that it accepts multiple pivot keys rather
than just a single key.

This makes is a bit more like the reshape2 function in R.

The function might also be brought closers to the R equivalent with the specification of both `id.vars` (pivot keys) and `measure.vars` (those to be normalised/ melted). I didn't need that at this time however. If this is a goal perhaps it's worth making the `pivot-keys` argument a vector rather than using &.
