### PR TITLE
New functions for series in dataset

### DIFF
--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -352,15 +352,6 @@
       (.removeSeries data-set series)
       chart)))
 
-(defn has-series?
-  "Test to see if a chart has a series name series-lab"
-  [chart series-label]
-  (try
-    (-> chart .getPlot .getDataset (.getSeries series-label))
-    true
-    (catch UnknownKeyException e
-      false)))
-
 (defn add-histogram*
   ([chart x & options]
     (let [opts (when options (apply assoc {} options))
@@ -575,6 +566,7 @@
         (.setRenderer n line-renderer))
       chart)))
 
+;; This one is not recommended, should use update-series instead.
 (defn extend-line
   " Add new data set to an exiting series if it already exists,
     otherwise, data set will be added to a newly created series. "
@@ -599,6 +591,57 @@
               (.add series (double x) (double y))))
           _x _y))
     chart))
+
+(defn get-series-by-label
+  "Return the series with name specified in series-label.
+   When supplied with a dataset index, this will only return the series
+   with given name in that particular dataset, this will make the search
+   faster."
+  ([chart series-label]
+   (let [plot (-> chart .getPlot)]
+     (loop [n (dec (.getDatasetCount plot))]
+       (let [series (try
+                      (-> plot (.getDataset n) (.getSeries series-label))
+                      (catch UnknownKeyException e
+                        nil))]
+         (if series
+           {:series series :index n}
+           (if (= n 0)
+             nil
+             (recur (dec n))))))))
+  ([chart series-label index]
+   (let [dataset (-> chart .getPlot (.getDataset index))]
+     (when dataset
+       (try (.getSeries dataset series-label)
+            (catch UnknownKeyException e
+              nil))))))
+
+(defn update-series
+  "Identify a series by series-label, then add new data to that series.
+   Optionally, old data can be removed.
+   If the series cannot be found, function returns nil, and nothing will
+   be changed."
+  [chart series-label x y & options]
+  (let [opts       (when options (apply assoc {} options))
+        data       (or (:data  opts) $data)
+        index      (or (:index opts) -1)
+        _x         (data-as-list x data)
+        _y         (data-as-list y data)
+        clean?     (or (:clean opts) false)
+        series     (if (>= index 0)
+                     (get-series-by-label chart series-label index)
+                     (:series (get-series-by-label chart series-label)))]
+    (if series
+      (do
+        (when clean? (.clear series))
+        (dorun
+         (map (fn [x y]
+                (if (and (not (nil? x))
+                         (not (nil? y)))
+                  (.add series (double x) (double y))))
+              _x _y))
+        chart)
+      nil)))
 
 ;; doesn't work
 (defmethod add-lines* org.jfree.data.statistics.HistogramDataset
@@ -3434,7 +3477,66 @@
                      (.getDataset series-idx)
                      .getSeries)))))
 
+(defn has-series?
+  "Examine if series-label is in any of the datasets of given chart."
+  [chart series-label]
+  (if (get-series-by-label chart series-label) true false))
 
+(defn list-series
+  "List all the series label and the index of the dataset they are in."
+  [chart]
+  (let [plot       (-> chart .getPlot)
+        count      (.getDatasetCount plot)
+        series-map (transient {})]
+    (doseq [n (range count)]
+      (let [dataset      (.getDataset plot n)
+            series-count (.getSeriesCount dataset)]
+        ;; (println series-count)
+        (assoc! series-map n (mapv (fn [i] (.getSeriesKey dataset i)) (range series-count)))))
+    (persistent! series-map)))
+
+(defn remove-series
+  "Remove an existing series speicified by series-label.
+   If the series does not exist it return nil.
+   Note: this will remove duplicated series labels"
+  ([chart series-label]
+   (let [plot (-> chart .getPlot)]
+     (loop [n     (dec (.getDatasetCount plot))
+            count 0]
+       (let [dataset (.getDataset plot n)
+             series  (try
+                       (.getSeries dataset series-label)
+                       (catch UnknownKeyException e
+                         nil))]
+         (if series
+           (do
+             (.removeSeries dataset series)
+             (if (= n 0)
+               (inc count)
+               (recur (dec n) (inc count))))
+           (if (= n 0)
+             count
+             (recur (dec n) count)))))))
+  ([chart series-label index]
+   ))
+
+(defn clear-chart
+  ""
+  [chart]
+  (let [plot       (-> chart .getPlot)
+        count      (.getDatasetCount plot)]
+    (doseq [n (range count)]
+      (let [dataset (.getDataset plot n)
+            series-count (.getSeriesCount dataset)]
+        ;; (println series-count)
+        (doseq [i (range series-count)]
+          (.removeSeries dataset i))))
+    chart))
+
+(defn get-dataset
+  ""
+  [chart index]
+  (-> chart .getPlot (.getDataset index)))
 
 (defmethod set-data org.jfree.chart.JFreeChart
   ([chart data]

--- a/modules/incanter-charts/test/incanter/charts_tests.clj
+++ b/modules/incanter-charts/test/incanter/charts_tests.clj
@@ -452,4 +452,27 @@
     (remove-series chart :series2)
     (is (= (has-series? chart :series2) false))))
 
+(deftest update-series-test
+  (let [x1 (range 10)
+        y1 (mapv (fn [_] (rand 10)) x1)
+        x2 (range 5)
+        y2 (mapv (fn [_] (rand 5)) x2)
+        x3 (range 10 20)
+        y3 (mapv (fn [_] (rand 10)) x1)
+        chart (xy-plot  x1 y1 :series-label :series_a_line :legend true)]
+    (testing "list-series"
+      (add-points chart x1 y1 :series-label :series_a_points)
+      (add-points chart x2 y2 :series-label :series_b)
+      (is (= (list-series chart)
+             {0 [:series_a_line], 1 [:series_a_points], 2 [:series_b]}))
+      (is (= (has-series? chart :series_b) true))
+      (is (= (has-series? chart :series_c) false))
+      (update-series chart :series_a_points x3 y3 :clean true)
+      (update-series chart :series_a_line   x3 y3 :clean true)
+      (is (= (remove-series chart :series_b) 1))
+      (is (= (remove-series chart :series_b) 0))
+      (is (= (has-series? chart :series_b) false))
+      (is (= (list-series chart)
+             {0 [:series_a_line], 1 [:series_a_points], 2 []})))))
+
 ; (run-tests)


### PR DESCRIPTION
New series function:  
  - update-series: update a series' data points with either append or overwrite. This should work on both scatter plots and line plots. Also since time series is a line plot (xy-plot), it should work for that too. I only tests for the scatter plot and line plot
  - remove-series: remove a series with a given label name in all datasets
  - get-series-by-label: search through all datasets in order, return the series that has given label. If not found, return nil. Note that, there is a get-series function already, so I named this as get-series-by-label. But I do feel the existing get-series behavior is not correct, since it returns all series of given datasets. I suggest that one should be renamed as get-all-series, and this get-series-by-label should be named as get-series. Of course, there is backward compatibility issue to consider, so maybe it's good to rename them for 2.0 release?
  - list-series: list all the series in a has-map format with keys are dataset IDs.
  - clear-chart: remove all the series from all the dataset. The chart will be empty after this.
  - get-dataset: return a dataset by index

Corrected function behaviors:
  - has-series?: previously can only tell if the primary dataset has given label. But since in one chart, there could be more than one datasets, this function should search through all datasets, and return true or false based on result.

Also added some tests for this these functions as well.