### PR TITLE
Fix core.matrix svd usage

### DIFF
--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -1533,10 +1533,11 @@
         (DoubleArrayList. (double-array xx))
         (DoubleArrayList. (double-array yy)))))
   ([mat]
-    (let [n (ncol mat)]
+   (let [n (ncol mat)
+         m (nrow mat)]
       (matrix
-        (for [i (range n) j (range n)]
-          (covariance (sel mat true i) (sel mat true j))) n))))
+        (for [i (range m) j (range m)]
+          (covariance (sel mat :rows i) (sel mat :rows j))) n))))
 
 
 

--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -2725,7 +2725,7 @@
   "
   ([x & options]
     (let [svd (decomp-svd (correlation x))
-          rotation (:V svd)
+          rotation (:V* svd)
           std-dev (sqrt (:S svd))]
       {:std-dev std-dev
        :rotation rotation})))

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -169,6 +169,16 @@
   ;; get the covariance between two variables
   (is (= (Math/round (covariance x y)) 2263)))
 
+(defn covariance-matrix-test []
+  ;; get the covariance from a matrix
+  (let [in [[9   8  7]
+            [90 80 70]
+            [10  5  0]]
+        result [[ 1.  10.  5.]
+                [10. 100. 50.]
+                [ 5.  50. 25.]]]
+    (is (= (to-vect (covariance in)) (to-vect result)))))
+
 (defn covariance-test-2 []
   (is (= 5.333333333333333
 	 (covariance
@@ -393,6 +403,7 @@
       (sd-test m1 x)
       (median-test x)
       (covariance-test x y)
+      (covariance-matrix-test)
       (covariance-test-2)
       (pearson-test)
       (correlation-ratio-example)

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -1,4 +1,4 @@
-;;; core-test-cases.clj -- Unit tests of Incanter functions 
+;;; core-test-cases.clj -- Unit tests of Incanter functions
 
 ;; by David Edgar Liebke http://incanter.org
 ;; October 31, 2009
@@ -362,6 +362,14 @@
  (let [r (simple-regression [2 4] [1 3])]
   (is (m/equals 3.0 (predict r 2)))))
 
+(defn principal-components-test [m]
+  ;; simple test to check if rotation and std-dev data gets set
+  (let [pca      (principal-components m)
+        rotation (:rotation pca)
+        std-dev   (:std-dev  pca)]
+    (is (not= rotation nil))
+    (is (not= std-dev nil))))
+
 (deftest compliance-test
   (doseq [impl [:clatrix :ndarray :persistent-vector :vectorz]]
     (set-current-implementation impl)
@@ -405,6 +413,10 @@
       (covariance-test x y)
       (covariance-matrix-test)
       (covariance-test-2)
+      ;; single value decomposition (SVD) not yet implemented for some
+      ;; types in core.matrix, thus skipping the test then
+      (when-not (some #{impl} '(:ndarray :persistent-vector))
+        (principal-components-test m1))
       (pearson-test)
       (correlation-ratio-example)
       (sample-test m2)

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -393,6 +393,7 @@
       (sd-test m1 x)
       (median-test x)
       (covariance-test x y)
+      (covariance-test-2)
       (pearson-test)
       (correlation-ratio-example)
       (sample-test m2)


### PR DESCRIPTION
Depends/includes https://github.com/incanter/incanter/pull/296

The wrong key of the core.matrix single value decomposition response was used, thus resulting in nil value for the rotation in principal component analysis.