### PR TITLE
Fix matrix correlation, covariance and PCA calculations

### DIFF
--- a/modules/incanter-core/project.clj
+++ b/modules/incanter-core/project.clj
@@ -13,6 +13,6 @@
                  [net.mikera/vectorz-clj "0.29.0" :exclusions [org.clojure/clojure]]
                  [net.mikera/core.matrix "0.36.1" :exclusions [org.clojure/clojure]]
                  [net.sourceforge.parallelcolt/parallelcolt "0.10.1"]]
-  :profiles {:dev {:dependencies [[clatrix "0.4.0" :exclusions [org.clojure/clojure]]
+  :profiles {:dev {:dependencies [[clatrix "0.5.0" :exclusions [org.clojure/clojure]]
                                   [org.jblas/jblas "1.2.3"]]}}
   )

--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -1582,9 +1582,10 @@
           (DoubleArrayList. (double-array yy)) (sd y))
         0.0)))
   ([mat]
-   (div (covariance mat)
-        (sqrt (mmult (diag (covariance mat)) (trans (diag (covariance mat))))))))
-
+   (let [trans-mat (trans mat)
+         cov-mat (covariance trans-mat)]
+     (div cov-mat
+       (sqrt (mult (diag cov-mat) (trans (diag cov-mat))))))))
 
 (defn auto-correlation
   "

--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -1533,11 +1533,10 @@
         (DoubleArrayList. (double-array xx))
         (DoubleArrayList. (double-array yy)))))
   ([mat]
-   (let [n (ncol mat)
-         m (nrow mat)]
+   (let [n (ncol mat)]
       (matrix
-        (for [i (range m) j (range m)]
-          (covariance (sel mat :rows i) (sel mat :rows j))) n))))
+        (for [i (range n) j (range n)]
+          (covariance (sel mat :cols i) (sel mat :cols j))) n))))
 
 
 
@@ -1582,10 +1581,10 @@
           (DoubleArrayList. (double-array yy)) (sd y))
         0.0)))
   ([mat]
-   (let [trans-mat (trans mat)
-         cov-mat (covariance trans-mat)]
-     (div cov-mat
-       (sqrt (mult (diag cov-mat) (trans (diag cov-mat))))))))
+   (let [n (ncol mat)]
+      (matrix
+        (for [i (range n) j (range n)]
+          (correlation (sel mat :cols i) (sel mat :cols j))) n))))
 
 (defn auto-correlation
   "
@@ -2725,12 +2724,11 @@
     http://en.wikipedia.org/wiki/Principal_component_analysis
   "
   ([x & options]
-    (let [svd (decomp-svd (correlation x))
-          rotation (:V* svd)
-          std-dev (sqrt (:S svd))]
-      {:std-dev std-dev
-       :rotation rotation})))
-
+   (let [svd (decomp-svd (covariance x))
+         rotation        (:V* svd)
+         std-dev         (sqrt (:S svd))]
+     {:std-dev std-dev
+      :rotation rotation})))
 
 
 (defn detabulate

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -204,8 +204,12 @@
 		 statistics)))))
 
 (defn correlation-matrix []
-  (let [mat [[1 2 3] [1 1 3] [2 1 4]]]
-    (is (m/equals [[1 -0.5 1] [-0.5 1 -0.5] [1 -0.5 1]]
+  (let [mat [[1 2 3]
+             [1 1 3]
+             [2 1 4]]]
+    (is (m/equals [[1 -0.5 1]
+                   [-0.5 1 -0.5]
+                   [1 -0.5 1]]
           (correlation mat)
           1E-7))))
 

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -201,6 +201,11 @@
 		 geometry
 		 statistics)))))
 
+(defn correlation-matrix []
+  (let [mat [[1 2 3] [1 1 3] [2 1 4]]]
+    (is (= [[1 -0.5 1] [-0.5 1 -0.5] [1 -0.5 1]]
+          (correlation mat)))))
+
 (defn sample-test [m]
   ;; test sample function
   (is (not= (sample (range 10) :replacement false) (range 10)))
@@ -419,6 +424,7 @@
         (principal-components-test m1))
       (pearson-test)
       (correlation-ratio-example)
+      (correlation-matrix)
       (sample-test m2)
       (ranking-test)
       (spearmans-rho-test)

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -174,10 +174,12 @@
   (let [in [[9   8  7]
             [90 80 70]
             [10  5  0]]
-        result [[ 1.  10.  5.]
-                [10. 100. 50.]
-                [ 5.  50. 25.]]]
-    (is (= (to-vect (covariance in)) (to-vect result)))))
+        result [[2160.333 1971.5 1782.667]
+                [1971.500 1803.0 1634.500]
+                [1782.667 1634.5 1486.333]]]
+    (is (m/equals (to-vect result)
+          (to-vect (covariance in))
+          1E-3))))
 
 (defn covariance-test-2 []
   (is (= 5.333333333333333
@@ -203,8 +205,9 @@
 
 (defn correlation-matrix []
   (let [mat [[1 2 3] [1 1 3] [2 1 4]]]
-    (is (= [[1 -0.5 1] [-0.5 1 -0.5] [1 -0.5 1]]
-          (correlation mat)))))
+    (is (m/equals [[1 -0.5 1] [-0.5 1 -0.5] [1 -0.5 1]]
+          (correlation mat)
+          1E-7))))
 
 (defn sample-test [m]
   ;; test sample function
@@ -368,12 +371,17 @@
   (is (m/equals 3.0 (predict r 2)))))
 
 (defn principal-components-test [m]
-  ;; simple test to check if rotation and std-dev data gets set
-  (let [pca      (principal-components m)
-        rotation (:rotation pca)
-        std-dev   (:std-dev  pca)]
-    (is (not= rotation nil))
-    (is (not= std-dev nil))))
+  (testing "principal components results"
+    (let [pca      (principal-components m)
+          rotation (:rotation pca)
+          std-dev   (:std-dev  pca)]
+      (is (not= rotation nil))
+      (is (not= std-dev nil))
+      (is (m/equals [[0.5773503 0.8164966  0]
+                     [0.5773503 0.4082483  0.7071068]
+                     [0.5773503 0.4082483  0.7071068]]
+            (abs rotation)
+            1E-6)))))
 
 (deftest compliance-test
   (doseq [impl [:clatrix :ndarray :persistent-vector :vectorz]]

--- a/modules/incanter-core/test/incanter/stats_tests.clj
+++ b/modules/incanter-core/test/incanter/stats_tests.clj
@@ -374,12 +374,12 @@
   (testing "principal components results"
     (let [pca      (principal-components m)
           rotation (:rotation pca)
-          std-dev   (:std-dev  pca)]
+          std-dev  (:std-dev  pca)]
       (is (not= rotation nil))
       (is (not= std-dev nil))
-      (is (m/equals [[0.5773503 0.8164966  0]
-                     [0.5773503 0.4082483  0.7071068]
-                     [0.5773503 0.4082483  0.7071068]]
+      (is (m/equals [[0.5773503 0.5773503 0.5773503]
+                     [0.8164966 0.4082483 0.4082483]
+                     [0.        0.7071068 0.7071068]]
             (abs rotation)
             1E-6)))))
 


### PR DESCRIPTION
- Fix correlation calculations for matrices.
- Make covariance calculate covariance on the data columns instead of rows, compliant with R.
- Make PCA use covariance instead of correlation, compliant with R.