### PR TITLE
Handle edge case in binary search where a single element vector would…

### DIFF
--- a/modules/incanter-core/src/incanter/interp/utils.clj
+++ b/modules/incanter-core/src/incanter/interp/utils.clj
@@ -2,19 +2,24 @@
   incanter.interp.utils)
 
 (defn binary-search
-"  Finds index of rightmost value in sorted vector that is less or equal to given value."
-[vec value]
-(if (= (count vec) 1)
-  0
+  "  Finds index of rightmost value in sorted vector that is less or equal to given value."
+  [vec value]
   (loop [left 0
          right (dec (count vec))]
+    (let [middle (quot (+ left right) 2)]
+      (cond
+       (= right left)
+       0
 
-    (if (= (- right left) 1)
-      (if (<= (nth vec right) value) right left)
-      (let [middle (quot (+ left right) 2)]
-        (if (<= (nth vec middle) value)
-          (recur middle right)
-          (recur left middle)))))))
+       (= (- right left) 1)
+       (if (<= (nth vec right) value) right left)
+
+
+       (<= (nth vec middle) value)
+       (recur middle right)
+
+       :else
+       (recur left middle)))))
 
 
 (defn find-segment

--- a/modules/incanter-core/src/incanter/interp/utils.clj
+++ b/modules/incanter-core/src/incanter/interp/utils.clj
@@ -14,7 +14,6 @@
        (= (- right left) 1)
        (if (<= (nth vec right) value) right left)
 
-
        (<= (nth vec middle) value)
        (recur middle right)
 

--- a/modules/incanter-core/src/incanter/interp/utils.clj
+++ b/modules/incanter-core/src/incanter/interp/utils.clj
@@ -3,15 +3,18 @@
 
 (defn binary-search
 "  Finds index of rightmost value in sorted vector that is less or equal to given value."
-  [vec value]
+[vec value]
+(if (= (count vec) 1)
+  0
   (loop [left 0
          right (dec (count vec))]
+
     (if (= (- right left) 1)
       (if (<= (nth vec right) value) right left)
       (let [middle (quot (+ left right) 2)]
         (if (<= (nth vec middle) value)
           (recur middle right)
-          (recur left middle))))))
+          (recur left middle)))))))
 
 
 (defn find-segment

--- a/modules/incanter-core/src/incanter/interpolation.clj
+++ b/modules/incanter-core/src/incanter/interpolation.clj
@@ -18,6 +18,9 @@
   (when-not (apply distinct? xs)
     (throw (IllegalArgumentException. "All x must be distinct."))))
 
+(defn- validate-more-than-one-point-given [xs]
+  (when-not (< 1 (count xs))
+    (throw (IllegalArgumentException. "Must give more than 1 point to interpolate over"))))
 
 (defn interpolate
   "
@@ -76,6 +79,7 @@
                    :linear-least-squares lls/interpolate)
           points (sort-by first points)
           opts (when options (apply assoc {} options))]
+      (validate-more-than-one-point-given points)
       (validate-unique (map first points))
       (method points opts)))
 

--- a/modules/incanter-core/test/incanter/interp/utils_tests.clj
+++ b/modules/incanter-core/test/incanter/interp/utils_tests.clj
@@ -21,6 +21,9 @@
        3 7
        6 12))
 
+(deftest binary-search-single-element-list-test
+  (is (= 0 (binary-search [1] 2))))
+
 (deftest find-segment-test
   (let [xs [0 1 2 3 4 5]]
     (are [x expected] (= (find-segment xs x) expected)


### PR DESCRIPTION
… result in it getting stuck in an infinite loop

We were using the piecewise-linear interpolation function and were (accidentally) passing it a single point to interpolate over. While, admittedly, this was as a result of a bug in our code, it caused the application to hang indefinitely while attempting to do the binary search, and this was very hard to debug.