### PR TITLE
Add Dockerfile for maven install and running tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM clojure
+
+RUN mkdir -p /usr/src/incanter
+
+WORKDIR /usr/src/incanter
+
+COPY . /usr/src/incanter/
+
+RUN lein modules install
+
+CMD lein modules test


### PR DESCRIPTION
To make this more easy to use in downstream images, Incanter gets
installed in local maven repository.
By default, running a container will run all Incanter tests.