### PR TITLE
Remove AOT from Incanter build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -49,16 +49,12 @@
 	  
   :profiles {:dev {:resource-paths ["data"]}
              :debug {:debug true}
-             :uberjar {:aot :all
-                       :main incanter.main
-                       :dependencies [[reply "0.3.7" :exclusions [org.clojure/clojure]]
+             :uberjar {:dependencies [[reply "0.3.7" :exclusions [org.clojure/clojure]]
                                       [swingrepl "1.3.0"
                                        :exclusions [org.clojure/clojure org.clojure/clojure-contrib]]
                                       ]
                        }
              }  
-  
-  :main incanter.main
   
   :repl-options {:init-ns incanter.irepl
                  :resource-paths ["data"]


### PR DESCRIPTION
Currently Incanter does a large-scale AOT compile, which results in a large jar size.

I believe it would be better to avoid AOT in the core build for the following reasons:

- It is unlikely to have significant performance benefits, since most of the performance senstive work is done in the underlying numerical libraries (Vectorz, Clatrix etc.)
- It may increase load times
- Users can always choose to create an AOT build using Incanter later if they wish