### PR TITLE
Add second arity for row-order to support custom index column names

### DIFF
--- a/modules/incanter-zoo/src/incanter/zoo.clj
+++ b/modules/incanter-zoo/src/incanter/zoo.clj
@@ -140,10 +140,11 @@
 
 (defn- row-order
   "Orders a seq of rows by index"
-  [z]
-  (->> z
-      (apply sorted-set-by #(compare (:index %1) (:index %2)))
-      (into [])))
+  ([z] (row-order z :index))
+  ([z index-col]
+   (->> z
+        (apply sorted-set-by #(compare (index-col %1) (index-col %2)))
+        (into []))))
 
 (defn- order
   "Order a zoo so that the :index is increasing in time."
@@ -168,7 +169,7 @@
   ([x index-col]
      {:pre [(-> x (ds/column-names) (in? index-col))]}
      (let [rows (ds/row-maps x)]
-       (->> (row-order rows)
+       (->> (row-order rows index-col)
             (map (fn [{i index-col :as v}]
                    (-> v
                        (dissoc index-col)

--- a/modules/incanter-zoo/test/incanter/zoo_test.clj
+++ b/modules/incanter-zoo/test/incanter/zoo_test.clj
@@ -65,7 +65,11 @@
       (is (= ts
              (zoo (to-dataset [{:index "2012-01-03" :a 3}
                                {:index "2012-01-02" :a 2}
-                               {:index "2012-01-01" :a 1}])))))))
+                               {:index "2012-01-01" :a 1}]))))))
+  (testing "Preserve all rows"
+    (is (= (nrow ds1) (nrow (zoo ds1))))
+    (is (= (nrow ds2) (nrow (zoo ds2 :date))))
+    (is (= (nrow ds3) (nrow (zoo ds3 :date))))))
 
 (defn $$-test []
   ;; Time slicing


### PR DESCRIPTION
Removed hard coded `:index` key in row-order function and added a second arity for row-order to allow for incanter.zoo/zoo to work with custom column names.
See issue #317