### PR TITLE
Exclude `clojure.core/update` in `incanter.core`

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -41,7 +41,8 @@
            (cern.colt.list.tdouble DoubleArrayList)
            (cern.jet.stat.tdouble DoubleDescriptive Gamma)
            (javax.swing JTable JScrollPane JFrame)
-           (java.util Vector)))
+           (java.util Vector))
+  (:refer-clojure :exclude [update]))
 
 
 (def ^{:dynamic true


### PR DESCRIPTION
Clojure 1.7 introduces `clojure.core/update`, which means that prior
to this commit `incanter.core/update` would shadow the `clojure.core`
var and throw a warning.  This commit uses:

    (:refer-clojure :exclude [...])

...to make the `clojure.core` var not in scope in `incanter.core`,
preventing the warning.  `incanter.core` never refers the
`clojure.core` var, so there should not be any negative effects of
this exclusion.

Prevents the following warning:

    WARNING: update already refers to: #'clojure.core/update in namespace: incanter.core, being replaced by: #'incanter.core/update