### PR TITLE
 fixed dataset save, which was failing on core.matrix's dataset

### DIFF
--- a/modules/incanter-io/src/incanter/io.clj
+++ b/modules/incanter-io/src/incanter/io.clj
@@ -137,15 +137,14 @@
         (.write file-writer (str \newline)))
       (doseq [row rows]
         (do
-          (.write file-writer (str (row (first columns))))
-          (doseq [column-name (rest columns)]
-            (.write file-writer (str delim (row column-name))))
+          (.write file-writer (str (first row)))
+          (doseq [i (rest row)]
+            (.write file-writer (str delim i)))
           (.write file-writer (str \newline))))
       (finally
         (.flush file-writer)
         (when (= "-" filename)
           (.close file-writer))))))
-
 
 (defmethod save java.awt.image.BufferedImage
   ([img filename & {:keys [format] :or {format "png"}}]


### PR DESCRIPTION
Fixed the save method on a dataset of type clojure.core.matrix.impl.dataset.DataSet which was failing, because of an exception to invocation to row (line 140) : ClasscastException: DataSetRow cannot be cast to clojure.lang.Ifn.

Added test to have a read-write-read roundtrip on the cars dataset. 

