### PR TITLE
Fix $rollup for clojure.core.matrix.dataset

### DIFF
--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -1788,7 +1788,7 @@
                      (into [] (map #(map-get row %) col-name)))
                    (fn [row]
                      (map-get row col-name)))
-          rows (:rows data)
+          rows (ds/row-maps data)
           rollup-fns {:max (fn [col-data] (apply max col-data))
                       :min (fn [col-data] (apply min col-data))
                       :sum (fn [col-data] (apply + col-data))
@@ -1800,9 +1800,11 @@
       (loop [cur rows reduced-rows {}]
         (if (empty? cur)
           (let [group-cols (to-dataset (keys reduced-rows))
-                res (conj-cols group-cols (map rollup-fn (vals reduced-rows)))]
-            (col-names res (concat (col-names group-cols)
-                                   (if (coll? col-name) col-name [col-name]))))
+                res (conj-cols group-cols (map rollup-fn (vals reduced-rows)))
+                new-col-names (concat (col-names group-cols)
+                                      (if (coll? col-name) col-name [col-name]))]
+            (ds/rename-columns res (zipmap (col-names res)
+                                           new-col-names)))
           (recur (next cur)
                  (let [row (first cur)
                        k (submap row group-by)

--- a/modules/incanter-core/test/incanter/core_tests.clj
+++ b/modules/incanter-core/test/incanter/core_tests.clj
@@ -586,3 +586,10 @@
                 table-column-names (map #(.getColumnName (.getModel table) %)
                                      (range (length column-names)))]
             (is (= column-names table-column-names)))))))))
+
+(deftest $rollup-test
+  (testing "rollup with mean"
+    (let [data (to-dataset [{:sex "Male" :height 1.5}
+                            {:sex "Male" :height 1.7}])]
+      (is (= (to-dataset [{:sex "Male" :height 1.6}])
+             ($rollup :mean :height :sex data ))))))


### PR DESCRIPTION
# Summary

`$rollup` in 1.9.1-SNAPSHOT fails with the `ArityException` when passing in a `clojure.core.matrix.dataset`

`ArityException Wrong number of args (2) passed to: core/col-names  clojure.lang.AFn.throwArity (AFn.java:429)`
# Reproduction Steps

```
(require '[incanter.core :as i])
(def data (i/to-dataset [{:sex "Male" :height 1.5} {:sex "Male" :height 1.7}]))
(i/$rollup :mean :sex :height data)
```
