### PR TITLE
Fix exclusion of relocated bouncycastle dependency to make it possibl…

### DIFF
--- a/modules/incanter-pdf/project.clj
+++ b/modules/incanter-pdf/project.clj
@@ -9,7 +9,6 @@
   :min-lein-version "2.0.0"
   :dependencies [[incanter/incanter-charts "1.9.4-SNAPSHOT"]
                  [com.lowagie/itext "2.1.7"
-                  :exclusions [org.bouncycastle/bctsp-jdk14 bouncycastle/bcprov-jdk14
-                               bouncycastle/bcmail-jdk14]]
-                 [org.bouncycastle/bctsp-jdk14 "1.46"]]
+                  :exclusions [bouncycastle/bctsp-jdk14]]
+                 [org.bouncycastle/bctsp-jdk14 "1.38"]]
   )


### PR DESCRIPTION
…e to use incanter with clojure cli. Issue #388.

```sh
╭─anthony@avalon ~/Desktop/incanter/incanter  ‹master*›  10:49:55
╰─$ clj -Sdeps '{:deps {incanter {:mvn/version "1.9.3"}}}'
Error building classpath. Could not find artifact bouncycastle:bctsp-jdk14:jar:138 in central (https://repo1.maven.org/maven2/)
╭─anthony@avalon ~/Desktop/incanter/incanter  ‹master*›  10:50:04
╰─$ clj -Sdeps '{:deps {incanter {:mvn/version "1.9.4-SNAPSHOT"}}}'                                                                                                                                         1 ↵
Clojure 1.10.0
user=>
```