### PR TITLE
Fix xvfb service initialisation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: clojure
+services:
+ - xvfb
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq libgfortran3
 install: lein modules install
 before_script:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
 script: lein modules test


### PR DESCRIPTION
### Problem
CI fails with `The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .` (see https://github.com/incanter/incanter/pull/407)

### Solution
Change how `xvfb` service is initialised in CI.