### PR TITLE
Migrate root incanter clojure from v1.8.0 to v1.10.1

### DIFF
--- a/modules/incanter-core/project.clj
+++ b/modules/incanter-core/project.clj
@@ -9,7 +9,7 @@
   :min-lein-version "2.0.0"
   :java-source-paths ["java"]
   :javac-options ["-target" "1.7" "-source" "1.7"]
-  :dependencies [[org.clojure/clojure "1.10.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/math.combinatorics "0.1.4" :exclusions [org.clojure/clojure]]
                  [net.mikera/vectorz-clj "0.44.1" :exclusions [org.clojure/clojure]]
                  [net.mikera/core.matrix "0.52.0" :exclusions [org.clojure/clojure]]

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [incanter/incanter-sql "1.9.4-SNAPSHOT"]
                  [incanter/incanter-zoo "1.9.4-SNAPSHOT"]
                  [swingrepl "1.3.0" :exclusions [org.clojure/clojure org.clojure/clojure-contrib]]
-                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/clojure "1.10.1"]
                  ]
   
   :plugins [[lein-sub "0.3.0"]


### PR DESCRIPTION
This commit updates [clojure version](https://github.com/incanter/incanter/blob/master/project.clj#L19) of the root incanter project from v1.8.0 to v1.10.1. Fixes issue #392 .

I haven't noticed any code breaking changes and all the tests still pass.