### PR TITLE
Fix Clojure 1.11 shadowing warning #426

### DIFF
--- a/modules/incanter-charts/project.clj
+++ b/modules/incanter-charts/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.tonsky/incanter-charts "1.9.4"
+(defproject io.github.tonsky/incanter-charts "1.9.5"
   :description "Incanter-charts is the JFreeChart module of the Incanter project."
   :url "http://incanter.org/"
   :license {:name "Eclipse Public License"
@@ -7,7 +7,7 @@
         :url "https://github.com/incanter/incanter"
         :dir "modules/incanter-charts"}
   :min-lein-version "2.0.0"
-  :dependencies [[io.github.tonsky/incanter-io "1.9.4"]
+  :dependencies [[io.github.tonsky/incanter-io "1.9.5"]
                  [org.jfree/jfreechart "1.5.0"]
                  [clj-time "0.14.0" :exclusions [org.clojure/clojure]]]
   :deploy-repositories

--- a/modules/incanter-charts/project.clj
+++ b/modules/incanter-charts/project.clj
@@ -1,4 +1,4 @@
-(defproject incanter/incanter-charts "1.9.4-SNAPSHOT"
+(defproject io.github.tonsky/incanter-charts "1.9.4"
   :description "Incanter-charts is the JFreeChart module of the Incanter project."
   :url "http://incanter.org/"
   :license {:name "Eclipse Public License"
@@ -7,7 +7,13 @@
         :url "https://github.com/incanter/incanter"
         :dir "modules/incanter-charts"}
   :min-lein-version "2.0.0"
-  :dependencies [[incanter/incanter-io "1.9.4-SNAPSHOT"]
+  :dependencies [[io.github.tonsky/incanter-io "1.9.4"]
                  [org.jfree/jfreechart "1.5.0"]
                  [clj-time "0.14.0" :exclusions [org.clojure/clojure]]]
+  :deploy-repositories
+  {"clojars"
+   {:url "https://clojars.org/repo"
+    :username "tonsky"
+    :password :env/clojars_token
+    :sign-releases false}}
   )

--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -27,6 +27,7 @@
             "
        :author "David Edgar Liebke"}
   incanter.charts
+  (:refer-clojure :exclude [abs])
   (:require [incanter.core :refer [$ matrix? dataset? vec? to-list plus minus div
                                    group-on bind-columns view save $group-by conj-cols
                                    grid-apply set-data col-names $data sel abs]

--- a/modules/incanter-charts/src/incanter/charts.clj
+++ b/modules/incanter-charts/src/incanter/charts.clj
@@ -76,6 +76,7 @@
                                          XYTextAnnotation
                                          XYPolygonAnnotation]))
 
+(set! *warn-on-reflection* false)
 
 
 (defmulti set-background-default

--- a/modules/incanter-core/project.clj
+++ b/modules/incanter-core/project.clj
@@ -1,4 +1,4 @@
-(defproject incanter/incanter-core "1.9.4-SNAPSHOT"
+(defproject io.github.tonsky/incanter-core "1.9.4"
   :description "Incanter-core is the core module of the Incanter project."
   :url "http://incanter.org/"
   :license {:name "Eclipse Public License"
@@ -8,7 +8,7 @@
         :dir "modules/incanter-core"}
   :min-lein-version "2.0.0"
   :java-source-paths ["java"]
-  :javac-options ["-target" "1.7" "-source" "1.7"]
+  :javac-options ["--release" "8"]
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/math.combinatorics "0.1.4" :exclusions [org.clojure/clojure]]
                  [net.mikera/vectorz-clj "0.44.1" :exclusions [org.clojure/clojure]]
@@ -16,4 +16,10 @@
                  [net.sourceforge.parallelcolt/parallelcolt "0.10.1"]]
   :profiles {:dev {:dependencies [[clatrix "0.5.0" :exclusions [org.clojure/clojure net.mikera/core.matrix]]
                                   [org.jblas/jblas "1.2.3"]]}}
+  :deploy-repositories
+  {"clojars"
+   {:url "https://clojars.org/repo"
+    :username "tonsky"
+    :password :env/clojars_token
+    :sign-releases false}}
   )

--- a/modules/incanter-core/project.clj
+++ b/modules/incanter-core/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.tonsky/incanter-core "1.9.4"
+(defproject io.github.tonsky/incanter-core "1.9.5"
   :description "Incanter-core is the core module of the Incanter project."
   :url "http://incanter.org/"
   :license {:name "Eclipse Public License"

--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -43,6 +43,8 @@
            (javax.swing JTable JScrollPane JFrame)
            (java.util Vector)))
 
+(set! *warn-on-reflection* false)
+
 (def ^{:dynamic true
        :doc "This variable is bound to a dataset when the with-data macro is used.
               functions like $ and $where can use $data as a default argument."}

--- a/modules/incanter-core/src/incanter/core.clj
+++ b/modules/incanter-core/src/incanter/core.clj
@@ -29,7 +29,7 @@
 
   incanter.core
 
-  (:refer-clojure :exclude [update])
+  (:refer-clojure :exclude [abs update])
   (:use [incanter internal]
         [incanter.infix :only (infix-to-prefix defop)]
         [clojure.set :only (difference)]

--- a/modules/incanter-core/src/incanter/distributions.clj
+++ b/modules/incanter-core/src/incanter/distributions.clj
@@ -26,6 +26,8 @@
         [clojure.math.combinatorics :only [combinations]]
         [incanter.core :only [gamma pow regularized-beta]]))
 
+(set! *warn-on-reflection* false)
+
 ;;utils
 (defn  next-raw
   "Wrapper fn to pull the next raw value from an

--- a/modules/incanter-core/src/incanter/optimize.clj
+++ b/modules/incanter-core/src/incanter/optimize.clj
@@ -19,6 +19,7 @@
 
 (ns ^{:doc "Optimization-relates functions."}
     incanter.optimize
+  (:refer-clojure :exclude [abs])
   (:use [incanter.core :only (plus minus div mult mmult symmetric-matrix ncol solve
                               matrix abs sel trans bind-columns to-list identity-matrix $=)])
   (:require [clojure.core.matrix :as m]))

--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -28,6 +28,7 @@
             "
        :author "David Edgar Liebke, Bradford Cross and Joaquin Iglesias Turina"}
   incanter.stats
+  (:refer-clojure :exclude [abs])
   (:import [cern.colt.list.tdouble DoubleArrayList]
            [cern.jet.random.tdouble Gamma Beta Binomial ChiSquare DoubleUniform
                                     Exponential NegativeBinomial Normal Poisson

--- a/modules/incanter-core/src/incanter/stats.clj
+++ b/modules/incanter-core/src/incanter/stats.clj
@@ -47,6 +47,8 @@
             [clojure.core.matrix.linear :as l]
             [incanter.distributions :as dist]))
 
+(set! *warn-on-reflection* false)
+
 (defn scalar-abs
   "Fast absolute value function"
   [x]

--- a/modules/incanter-io/project.clj
+++ b/modules/incanter-io/project.clj
@@ -1,4 +1,4 @@
-(defproject incanter/incanter-io "1.9.4-SNAPSHOT"
+(defproject io.github.tonsky/incanter-io "1.9.4"
   :description "Incanter-io is the I/O module of the Incanter project."
   :url "http://incanter.org/"
   :license {:name "Eclipse Public License"
@@ -7,7 +7,7 @@
         :url "https://github.com/incanter/incanter"
         :dir "modules/incanter-io"}
   :min-lein-version "2.0.0"
-  :dependencies [[incanter/incanter-core "1.9.4-SNAPSHOT"]
+  :dependencies [[io.github.tonsky/incanter-core "1.9.4"]
                  ;; TODO: switch to data.csv?
                  [net.sf.opencsv/opencsv "2.3"]
                  [org.clojure/data.csv "0.1.4"
@@ -17,4 +17,10 @@
                   :exclusions [org.clojure/clojure org.clojure/clojure-contrib]]]
   :profiles {:dev {:dependencies [[clatrix "0.5.0" :exclusions [org.clojure/clojure net.mikera/core.matrix]]
                                   [org.jblas/jblas "1.2.3"]]}}
+  :deploy-repositories
+  {"clojars"
+   {:url "https://clojars.org/repo"
+    :username "tonsky"
+    :password :env/clojars_token
+    :sign-releases false}}
   )

--- a/modules/incanter-io/project.clj
+++ b/modules/incanter-io/project.clj
@@ -1,4 +1,4 @@
-(defproject io.github.tonsky/incanter-io "1.9.4"
+(defproject io.github.tonsky/incanter-io "1.9.5"
   :description "Incanter-io is the I/O module of the Incanter project."
   :url "http://incanter.org/"
   :license {:name "Eclipse Public License"
@@ -7,7 +7,7 @@
         :url "https://github.com/incanter/incanter"
         :dir "modules/incanter-io"}
   :min-lein-version "2.0.0"
-  :dependencies [[io.github.tonsky/incanter-core "1.9.4"]
+  :dependencies [[io.github.tonsky/incanter-core "1.9.5"]
                  ;; TODO: switch to data.csv?
                  [net.sf.opencsv/opencsv "2.3"]
                  [org.clojure/data.csv "0.1.4"

--- a/modules/incanter-zoo/src/incanter/zoo.clj
+++ b/modules/incanter-zoo/src/incanter/zoo.clj
@@ -23,6 +23,7 @@
             (http://acs.lbl.gov/~hoschek/colt/)."
         :author "David Edgar Liebke"}
    incanter.zoo
+   (:refer-clojure :exclude [abs])
    (:import (cern.colt.list.tdouble DoubleArrayList))
    (:use incanter.backstage.zoo-commons
          [incanter.core :only ($ abs plus minus div mult mmult to-list bind-columns dataset


### PR DESCRIPTION
After Clojure 1.11 added abs to the core, importing incanter prints these warnings:

```
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.core, being replaced by: #'incanter.core/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.charts, being replaced by: #'incanter.core/abs
WARNING: abs already refers to: #'clojure.core/abs in namespace: incanter.stats, being replaced by: #'incanter.core/abs
```

This PR solves #426 